### PR TITLE
Built-in Authorizing Payment scene

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ file as follows:
 
 ```xml
 <activity
-  android:name="co.omise.android.ui.Verify3DSActivity"
+  android:name="co.omise.android.ui.AuthorizingPaymentActivity"
   android:theme="@style/OmiseSDKTheme" />
 ```
 

--- a/app/src/main/java/co/omise/android/example/MainActivity.java
+++ b/app/src/main/java/co/omise/android/example/MainActivity.java
@@ -9,12 +9,12 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import co.omise.android.ui.Verify3DSActivity;
+import co.omise.android.ui.AuthorizingPaymentActivity;
 
 public class MainActivity extends BaseActivity implements AdapterView.OnItemClickListener {
     private ProductListAdapter listAdapter = null;
 
-    private static int VERIFY_3DS_REQUEST_CODE = 0x3D5;
+    private static int AUTHORIZING_PAYMENT_REQUEST_CODE = 0x3D5;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,10 +44,10 @@ public class MainActivity extends BaseActivity implements AdapterView.OnItemClic
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.menu_3ds_verify_action) {
-            Intent intent = new Intent(this, Verify3DSActivity.class);
-            intent.putExtra(Verify3DSActivity.EXTRA_AUTHORIZED_URL, "https://api.omise.co/payments/paym_12345/authorize");
-            startActivityForResult(intent, MainActivity.VERIFY_3DS_REQUEST_CODE);
+        if (item.getItemId() == R.id.menu_authorizing_payment_action) {
+            Intent intent = new Intent(this, AuthorizingPaymentActivity.class);
+            intent.putExtra(AuthorizingPaymentActivity.EXTRA_AUTHORIZED_URL, "https://pay.omise.co/offsites/ofsp_test_58ict2lab9fux0l9uuk/pay");
+            startActivityForResult(intent, MainActivity.AUTHORIZING_PAYMENT_REQUEST_CODE);
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -55,8 +55,8 @@ public class MainActivity extends BaseActivity implements AdapterView.OnItemClic
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == MainActivity.VERIFY_3DS_REQUEST_CODE && resultCode == RESULT_OK) {
-            String url = data.getStringExtra(Verify3DSActivity.EXTRA_REDIRECTED_URL);
+        if (requestCode == MainActivity.AUTHORIZING_PAYMENT_REQUEST_CODE && resultCode == RESULT_OK) {
+            String url = data.getStringExtra(AuthorizingPaymentActivity.EXTRA_REDIRECTED_URL);
             Toast.makeText(getApplicationContext(), url, Toast.LENGTH_SHORT);
         }
         super.onActivityResult(requestCode, resultCode, data);

--- a/app/src/main/java/co/omise/android/example/MainActivity.java
+++ b/app/src/main/java/co/omise/android/example/MainActivity.java
@@ -46,7 +46,8 @@ public class MainActivity extends BaseActivity implements AdapterView.OnItemClic
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_authorizing_payment_action) {
             Intent intent = new Intent(this, AuthorizingPaymentActivity.class);
-            intent.putExtra(AuthorizingPaymentActivity.EXTRA_AUTHORIZED_URL, "https://pay.omise.co/offsites/ofsp_test_58ict2lab9fux0l9uuk/pay");
+            intent.putExtra(AuthorizingPaymentActivity.EXTRA_AUTHORIZED_URLSTRING, "https://pay.omise.co/offsites/");
+            intent.putExtra(AuthorizingPaymentActivity.EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, new String[] {"http://www.example.com/orders"} );
             startActivityForResult(intent, MainActivity.AUTHORIZING_PAYMENT_REQUEST_CODE);
             return true;
         }
@@ -56,8 +57,8 @@ public class MainActivity extends BaseActivity implements AdapterView.OnItemClic
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == MainActivity.AUTHORIZING_PAYMENT_REQUEST_CODE && resultCode == RESULT_OK) {
-            String url = data.getStringExtra(AuthorizingPaymentActivity.EXTRA_REDIRECTED_URL);
-            Toast.makeText(getApplicationContext(), url, Toast.LENGTH_SHORT);
+            String url = data.getStringExtra(AuthorizingPaymentActivity.EXTRA_RETURNED_URLSTRING);
+            Toast.makeText(getApplicationContext(), url, Toast.LENGTH_LONG).show();
         }
         super.onActivityResult(requestCode, resultCode, data);
     }

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/menu_3ds_verify_action"
+        android:id="@+id/menu_authorizing_payment_action"
         android:showAsAction="never"
-        android:title="@string/verify_3ds"/>
+        android:title="@string/authorize_payment"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,5 +7,5 @@
     <string name="description_product_image">Product Image</string>
     <string name="format_paid_with_card" formatted="false">You have paid %s with card %s.</string>
     <string name="format_price" formatted="false">THB %.2f</string>
-    <string name="verify_3ds">3DS Verify</string>
+    <string name="authorize_payment">Authorize Payment</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "26"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 26
         versionCode 2
         versionName "2.2.0"

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true">
         <activity android:name=".ui.CreditCardActivity" />
-        <activity android:name=".ui.Verify3DSActivity"></activity>
+        <activity android:name=".ui.AuthorizingPaymentActivity"></activity>
     </application>
 
 </manifest>

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
@@ -72,7 +72,6 @@ public class AuthorizingPaymentActivity extends Activity {
                     return false;
                 }
             }
-
         });
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
@@ -13,9 +13,9 @@ import co.omise.android.R;
 
 
 // This is an experimental helper class in our SDK which would help you to handle 3DS verification process within your apps out of the box.
-public class Verify3DSActivity extends Activity {
-    public static final String EXTRA_AUTHORIZED_URL = "Verify3DSActivity.authorizedURL";
-    public static final String EXTRA_REDIRECTED_URL = "Verify3DSActivity.redirectedURL";
+public class AuthorizingPaymentActivity extends Activity {
+    public static final String EXTRA_AUTHORIZED_URL = "AuthorizingPaymentActivity.authorizedURL";
+    public static final String EXTRA_REDIRECTED_URL = "AuthorizingPaymentActivity.redirectedURL";
 
 
     private WebView webView;
@@ -24,11 +24,11 @@ public class Verify3DSActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_verfiy_3ds);
-        webView = (WebView) findViewById(R.id.verify_3ds_webview);
+        setContentView(R.layout.activity_authorizing_payment);
+        webView = (WebView) findViewById(R.id.authorizing_payment_webview);
         webView.getSettings().setJavaScriptEnabled(true);
 
-        setTitle(R.string.title_verify_3ds);
+        setTitle(R.string.title_authorizing_payment);
 
         Intent intent = getIntent();
         try {
@@ -58,6 +58,20 @@ public class Verify3DSActivity extends Activity {
     }
 
     private Boolean verifyURL(String url) {
+        return  verify3DSURL(url) || verifyOffsiteURL(url);
+    }
+
+    private Boolean verifyOffsiteURL(String url) {
+        try {
+            URL currentURL = new URL(url);
+            String[] paths = currentURL.getPath().split("/");
+            return currentURL.getHost().startsWith("pay") && currentURL.getHost().endsWith("omise.co") && paths.length >= 2 && (paths[0].equalsIgnoreCase("offsites") || paths[1].equalsIgnoreCase("offsites")) && paths[paths.length - 1].equalsIgnoreCase("redirect");
+        } catch (MalformedURLException exception) {
+            return false;
+        }
+    }
+
+    private Boolean verify3DSURL(String url) {
         try {
             URL currentURL = new URL(url);
             String[] paths = currentURL.getPath().split("/");

--- a/sdk/src/main/res/layout/activity_authorizing_payment.xml
+++ b/sdk/src/main/res/layout/activity_authorizing_payment.xml
@@ -4,7 +4,7 @@
     android:id="@+id/activity_verfiy_3ds"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="co.omise.android.ui.Verify3DSActivity">
+    tools:context="co.omise.android.ui.AuthorizingPaymentActivity">
 
     <WebView
         android:layout_width="match_parent"
@@ -12,5 +12,5 @@
         android:layout_alignParentTop="true"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:id="@+id/verify_3ds_webview" />
+        android:id="@+id/authorizing_payment_webview" />
 </RelativeLayout>

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -14,6 +14,6 @@
     <string name="label_card_number">カード番号</string>
     <string name="label_expiry_date">有効期限</string>
     <string name="label_security_code">セキュリティコード</string>
-    <string name="title_verify_3ds">カード発行会社にご確認下さい</string>
+    <string name="title_authorizing_payment">決済を認証中</string>
     <string name="menu_card_io">カードを読み取る</string>
 </resources>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -15,5 +15,5 @@
     <string name="label_expiry_date">วันหมดอายุ</string>
     <string name="label_security_code">รหัสหลังบัตร</string>
     <string name="menu_card_io">ถ่ายรูปบัตร</string>
-    <string name="title_verify_3ds">ตรวจสอบกับธนาคารผู้ออกบัตร</string>
+    <string name="title_authorizing_payment">กำลังอนุมัติวงเงิน</string>
 </resources>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -14,6 +14,6 @@
     <string name="label_expiry_date">Expiry date</string>
     <string name="label_security_code">Security code</string>
     <string name="menu_card_io">Scan from Camera</string>
-    <string name="title_verify_3ds">Verify with card issuer</string>
+    <string name="title_authorizing_payment">Authorizing Payment</string>
     <string name="placeholder_security_code" translatable="false">CVV</string>
 </resources>


### PR DESCRIPTION
Since the Authorizing Payment is a common operation when using Omise service now. I think it would be great if we have the built-in way to support the Authorizing Payment in the SDK.

This PR introduces the `AuthorizingPaymentActivity` scene which replaces the old `Verify3DSActivity`. This new OmiseAuthorizingPaymentViewController requires the expected return URL patterns in order to make it work properly. The merchants/library-users need to specify their return URL patterns to this scene.