### PR TITLE
Added ProGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 ```
 
 
+## ProGuard Rules
+
+
+
+
+
 ## Contributing
 
 Pull requests and bugfixes are welcome. For larger scope of work, please pop on to our [forum](https://forum.omise.co) to discuss first.

--- a/README.md
+++ b/README.md
@@ -243,8 +243,14 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 
 ## ProGuard Rules
 
+When enable ProGuard, then add this rules in your ProGuard file.
 
-
+```ProGuard
+# Omise
+-dontwarn okio.**
+-dontwarn com.google.common.**
+-dontwarn org.joda.time.**
+```
 
 
 ## Contributing

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -15,7 +15,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/sdk/proguard-rules.pro
+++ b/sdk/proguard-rules.pro
@@ -1,17 +1,68 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/chakrit/Library/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Specify the input jars, output jars, and library jars.
+# In this case, the input jar is the program library that we want to process.
 
-# Add any project specific keep options here:
+# Save the obfuscation mapping to a file, so we can de-obfuscate any stack
+# traces later on. Keep a fixed source file attribute and all line number
+# tables to get line numbers in the stack traces.
+# You can comment this out if you're not interested in stack traces.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-printmapping out.map
+-keepparameternames
+-renamesourcefileattribute SourceFile
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,SourceFile,LineNumberTable,EnclosingMethod
+
+# Preserve all annotations.
+
+-keepattributes *Annotation*
+
+# Preserve all public classes, and their public and protected fields and
+# methods.
+
+-keep public class * {
+    public protected *;
+}
+
+# Preserve all .class method names.
+
+-keepclassmembernames class * {
+    java.lang.Class class$(java.lang.String);
+    java.lang.Class class$(java.lang.String, boolean);
+}
+
+# Preserve all native method names and the names of their classes.
+
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Preserve the special static methods that are required in all enumeration
+# classes.
+
+-keepclassmembers class * extends java.lang.Enum {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+# Explicitly preserve all serialization members. The Serializable interface
+# is only a marker interface, so it wouldn't save them.
+# You can comment this out if your library doesn't use serialization.
+# If your code contains serializable classes that have to be backward
+# compatible, please refer to the manual.
+
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+# Your library may contain more items that need to be preserved;
+# typically classes that are dynamically created using Class.forName:
+
+-keep public class co.omise.android.** { *; }
+-keep public interface co.omise.android.** { *; }
+-keep public class * implements co.omise.android.** { *; }
+
+-dontwarn okio.**

--- a/sdk/proguard-rules.pro
+++ b/sdk/proguard-rules.pro
@@ -64,5 +64,3 @@
 -keep public class co.omise.android.** { *; }
 -keep public interface co.omise.android.** { *; }
 -keep public class * implements co.omise.android.** { *; }
-
--dontwarn okio.**


### PR DESCRIPTION
**1. Objective**

To support Android ProGuard. 


**2. Description of change**

- Added rules for SDK's ProGuard
- Added documentation for using SDK with ProGuard


**3. How to test**

- On Android Studio in the sample project you can enable ProGuard by open `build.gradle` in sample project and edit `minifyEnabled` to `true`. 
- Change variant to `release`. 
- Create keystore for testing and add keystore config to `build.gradle` [more detail](https://developer.android.com/studio/publish/app-signing.html).
- On Android Studio toolbar `Build>Build APK` this will create release apk file.


