### PR TITLE
Fix credit card number format.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -17,6 +21,10 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -81,8 +81,6 @@ uploadArchives {
 dependencies {
     compile 'joda-time:joda-time:2.9.2'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile "com.android.support:support-annotations:26.1.0"
     androidTestCompile("com.android.support.test.espresso:espresso-core:3.0.1", {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 26
         versionCode 4
         versionName "2.6.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -80,6 +81,13 @@ uploadArchives {
 dependencies {
     compile 'joda-time:joda-time:2.9.2'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile "com.android.support:support-annotations:26.1.0"
+    androidTestCompile("com.android.support.test.espresso:espresso-core:3.0.1", {
+        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    })
     androidTestCompile 'com.google.guava:guava:19.0'
     provided 'io.card:android-sdk:5.4.0'
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -81,8 +81,8 @@ uploadArchives {
 dependencies {
     compile 'joda-time:joda-time:2.9.2'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile "com.android.support:support-annotations:26.1.0"
-    androidTestCompile("com.android.support.test.espresso:espresso-core:3.0.1", {
+    androidTestCompile 'com.android.support:support-annotations:26.1.0'
+    androidTestCompile('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     })

--- a/sdk/src/androidTest/java/co/omise/android/CreditCardEditTextTest.java
+++ b/sdk/src/androidTest/java/co/omise/android/CreditCardEditTextTest.java
@@ -1,0 +1,55 @@
+package co.omise.android;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.KeyEvent;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.pressKey;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class CreditCardEditTextTest {
+
+    @Rule
+    public ActivityTestRule<TestCreditCardEditTextActivity> rule = new ActivityTestRule<>(TestCreditCardEditTextActivity.class, true, true);
+
+    @Test
+    public void creditCard() throws InterruptedException {
+        onView(withId(R.id.credit_card_edit))
+                .perform(typeText("4242424242424242"), closeSoftKeyboard())
+                .check(matches(withText("4242 4242 4242 4242")));
+    }
+
+    @Test
+    public void enter5Digits() {
+        onView(withId(R.id.credit_card_edit))
+                .perform(typeText("42424"), closeSoftKeyboard())
+                .check(matches(withText("4242 4")));
+    }
+
+    @Test
+    public void delete() {
+        onView(withId(R.id.credit_card_edit))
+                .perform(typeText("42424"),
+                        pressKey(KeyEvent.KEYCODE_DEL),
+                        pressKey(KeyEvent.KEYCODE_DEL),
+                        closeSoftKeyboard())
+                .check(matches(withText("424")));
+    }
+
+    @Test
+    public void typeOver19Characters() {
+        onView(withId(R.id.credit_card_edit))
+                .perform(typeText("42424242424242424242424"), closeSoftKeyboard())
+                .check(matches(withText("4242 4242 4242 4242")));
+    }
+}

--- a/sdk/src/debug/AndroidManifest.xml
+++ b/sdk/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="co.omise.android">
+
+    <application>
+        <activity android:name=".TestCreditCardEditTextActivity"
+            android:theme="@style/Base.Theme.AppCompat.Light"/>
+    </application>
+</manifest>

--- a/sdk/src/debug/AndroidManifest.xml
+++ b/sdk/src/debug/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="co.omise.android">
 
     <application>
-        <activity android:name=".TestCreditCardEditTextActivity"
-            android:theme="@style/Base.Theme.AppCompat.Light"/>
+        <activity android:name=".TestCreditCardEditTextActivity"/>
     </application>
 </manifest>

--- a/sdk/src/debug/java/co/omise/android/TestCreditCardEditTextActivity.java
+++ b/sdk/src/debug/java/co/omise/android/TestCreditCardEditTextActivity.java
@@ -1,20 +1,13 @@
 package co.omise.android;
 
+import android.app.Activity;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 
-import co.omise.android.ui.CreditCardEditText;
-
-public class TestCreditCardEditTextActivity extends AppCompatActivity {
-
-    CreditCardEditText creditCardEdit;
+public class TestCreditCardEditTextActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_test_credit_card_edit_text);
-
-        creditCardEdit = findViewById(R.id.credit_card_edit);
-
     }
 }

--- a/sdk/src/debug/java/co/omise/android/TestCreditCardEditTextActivity.java
+++ b/sdk/src/debug/java/co/omise/android/TestCreditCardEditTextActivity.java
@@ -1,0 +1,20 @@
+package co.omise.android;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import co.omise.android.ui.CreditCardEditText;
+
+public class TestCreditCardEditTextActivity extends AppCompatActivity {
+
+    CreditCardEditText creditCardEdit;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_test_credit_card_edit_text);
+
+        creditCardEdit = findViewById(R.id.credit_card_edit);
+
+    }
+}

--- a/sdk/src/debug/res/layout/activity_test_credit_card_edit_text.xml
+++ b/sdk/src/debug/res/layout/activity_test_credit_card_edit_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_width="200dp"
         android:layout_height="wrap_content" />
 
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>

--- a/sdk/src/debug/res/layout/activity_test_credit_card_edit_text.xml
+++ b/sdk/src/debug/res/layout/activity_test_credit_card_edit_text.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="co.omise.android.TestCreditCardEditTextActivity">
+
+    <co.omise.android.ui.CreditCardEditText
+        android:id="@+id/credit_card_edit"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content" />
+
+</android.support.constraint.ConstraintLayout>

--- a/sdk/src/debug/res/values/strings.xml
+++ b/sdk/src/debug/res/values/strings.xml
@@ -1,0 +1,1 @@
+<resources></resources>

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.java
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.java
@@ -61,7 +61,6 @@ public class CreditCardEditText extends EditText {
                     e.delete(e.length() - 1, e.length());
                 }
             }
-
         });
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.java
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.java
@@ -3,14 +3,14 @@ package co.omise.android.ui;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.view.KeyEvent;
 import android.widget.EditText;
 
 public class CreditCardEditText extends EditText {
-    private boolean suppressEvent = false;
 
     public CreditCardEditText(Context context) {
         super(context);
@@ -36,49 +36,33 @@ public class CreditCardEditText extends EditText {
     private void init() {
         setFilters(new InputFilter[]{new InputFilter.LengthFilter(19)});
         setInputType(InputType.TYPE_CLASS_PHONE);
+
+        addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable e) {
+                if (e.length() <= 0 || (e.length() % 5) != 0) {
+                    return;
+                }
+
+                char c = e.charAt(e.length() - 1);
+                if (Character.isDigit(c)) {
+                    // Insert space bar
+                    e.insert(e.length() - 1, " ");
+                } else if (c == ' ') {
+                    // Delete space bar
+                    e.delete(e.length() - 1, e.length());
+                }
+            }
+
+        });
     }
 
-    /* inject SPC and DEL keys as the user types to make sure the textbox always show numbers in
-     * groups of 4.
-     *
-     * For example:
-     * [1234]   -> input [5]  output [1234 5] (space + 5)
-     * [1234 5] -> input [^H] output [1234]   (del + del)
-     */
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (suppressEvent) {
-            return super.onKeyDown(keyCode, event);
-        }
-
-        int length = getText().length();
-        boolean beforeSeparator = (length - 4) % 5 == 0;
-        boolean afterSeparator = length % 5 == 0;
-        if (isDeletion(keyCode) && afterSeparator) {
-            sendKey(KeyEvent.KEYCODE_DEL);
-        } else if (isDigit(keyCode) && beforeSeparator) {
-            sendKey(KeyEvent.KEYCODE_SPACE);
-        }
-
-        return super.onKeyDown(keyCode, event);
-    }
-
-    private boolean isDigit(int keyCode) {
-        return (KeyEvent.KEYCODE_0 <= keyCode && keyCode <= KeyEvent.KEYCODE_9) ||
-                (KeyEvent.KEYCODE_NUMPAD_0 <= keyCode && keyCode <= KeyEvent.KEYCODE_NUMPAD_9);
-    }
-
-    private boolean isDeletion(int keyCode) {
-        return keyCode == KeyEvent.KEYCODE_DEL;
-    }
-
-    private void sendKey(int keyCode) {
-        suppressEvent = true;
-        try {
-            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
-            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyCode));
-        } finally {
-            suppressEvent = false;
-        }
-    }
 }


### PR DESCRIPTION
This PR fixed issue #27. Because of `OnKeyListener` will fired only hardware keyboard and not working with alternative keyboards. To solve format on `CreditCardEditText`, use `TextWatcher` instead of `OnKeyListener` to format credit card number.