### PR TITLE
Handle authorize uri with external app

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 
+#### Authorizing Payment via an external app
+
+Some request method allow user to authorize with external app, for sample Alipay. When user would like to authorize their payment with external app, `AuthorizingPaymentActivity` will automatically open external app by default. However merchant developers handle the `Intent` callback by themselves.
 
 ## ProGuard Rules
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 
 #### Authorizing Payment via an external app
 
-Some request method allow user to authorize with external app, for sample Alipay. When user would like to authorize their payment with external app, `AuthorizingPaymentActivity` will automatically open external app by default. However merchant developers handle the `Intent` callback by themselves.
+Some request methods allow the user to authorize the payment with an external app, for example Alipay. When a user would like to authorize the payment with an external app, `AuthorizingPaymentActivity` will automatically open an external app by default. However merchant developers must handle the `Intent` callback by themselves.
 
 ## ProGuard Rules
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,8 @@
             android:name="io.card.payment.CardIOActivity"
             android:configChanges="keyboardHidden|orientation" />
 
+        <activity android:name="co.omise.android.ui.AuthorizingPaymentActivity" />
+
     </application>
 
 </manifest>

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
@@ -1,6 +1,7 @@
 package co.omise.android.ui;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -113,9 +114,14 @@ public class AuthorizingPaymentActivity extends Activity {
                     finish();
                     return true;
                 } else if (verifier.verifyExternalURL(uri)) {
-                    Intent externalIntent = new Intent(Intent.ACTION_VIEW, uri);
-                    startActivityForResult(externalIntent, REQUEST_EXTERNAL_CODE);
-                    return true;
+                    try {
+                        Intent externalIntent = new Intent(Intent.ACTION_VIEW, uri);
+                        startActivityForResult(externalIntent, REQUEST_EXTERNAL_CODE);
+                        return true;
+                    } catch (ActivityNotFoundException e) {
+                        e.printStackTrace();
+                        return false;
+                    }
                 } else {
                     return false;
                 }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.java
@@ -4,16 +4,16 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
 import java.util.ArrayList;
-
 import co.omise.android.R;
 
 
-// This is an experimental helper class in our SDK which would help you to handle 3DS verification process within your apps out of the box.
+/**
+ * This is an experimental helper class in our SDK which would help you to handle 3DS verification process within your apps out of the box.
+ * In case authorize with external app. By default open those external app when completed verification then sent result back our SDK.
+ */
 public class AuthorizingPaymentActivity extends Activity {
     public static final String EXTRA_AUTHORIZED_URLSTRING = "AuthorizingPaymentActivity.authorizedURL";
     public static final String EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS = "AuthorizingPaymentActivity.expectedReturnURLPatterns";
@@ -105,7 +105,6 @@ public class AuthorizingPaymentActivity extends Activity {
         webView.setWebViewClient(new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                Log.d("webview_url", url);
                 Uri uri = Uri.parse(url);
                 if (verifier.verifyURL(uri)) {
                     Intent resultIntent = new Intent();


### PR DESCRIPTION
Supported authorize URI with external app, for example Alipay app. `AuthrizingPaymentActivity` automatically open external app when authorize URI was not `https, http, about` scheme. When user confirmed payment from external app, then will pass result back to `onActivityResult()` in merchant app.