### PR TITLE
Fix spinner default view

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/NumberRangeSpinnerAdapter.java
+++ b/sdk/src/main/java/co/omise/android/ui/NumberRangeSpinnerAdapter.java
@@ -53,7 +53,7 @@ public abstract class NumberRangeSpinnerAdapter implements SpinnerAdapter {
         Context context = parent.getContext();
         if (convertView == null) {
             LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            convertView = inflater.inflate(android.R.layout.simple_spinner_dropdown_item, parent, false);
+            convertView = inflater.inflate(android.R.layout.simple_spinner_item, parent, false);
         }
 
         TextView textView = (TextView) convertView.findViewById(android.R.id.text1);

--- a/sdk/src/main/res/layout/activity_credit_card.xml
+++ b/sdk/src/main/res/layout/activity_credit_card.xml
@@ -19,8 +19,8 @@
             android:id="@id/edit_card_number"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             android:hint="@string/label_card_number"
             android:nextFocusForward="@id/edit_card_name" />
@@ -29,8 +29,8 @@
             android:id="@id/image_card_brand"
             android:layout_width="wrap_content"
             android:layout_height="44dp"
-            android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
             android:contentDescription="@string/description_brand_logo" />
 
@@ -58,63 +58,51 @@
         android:baselineAligned="false"
         android:orientation="horizontal">
 
-        <LinearLayout
+        <TextView
+            android:id="@id/text_expiry_date"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:orientation="vertical">
+            android:text="@string/label_expiry_date" />
 
-            <TextView
-                android:id="@id/text_expiry_date"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/label_expiry_date" />
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <Spinner
-                    android:id="@id/spinner_expiry_month"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:nextFocusForward="@id/spinner_expiry_year"
-                    android:spinnerMode="dialog" />
-
-                <Spinner
-                    android:id="@id/spinner_expiry_year"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:nextFocusForward="@id/edit_security_code"
-                    android:spinnerMode="dialog" />
-
-            </LinearLayout>
-
-        </LinearLayout>
-
-        <LinearLayout
+        <TextView
+            android:id="@id/text_security_code"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:orientation="vertical">
+            android:text="@string/label_security_code" />
+    </LinearLayout>
 
-            <TextView
-                android:id="@id/text_security_code"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/label_security_code" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:baselineAligned="false"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
-            <EditText
-                android:id="@id/edit_security_code"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/placeholder_security_code"
-                android:inputType="numberPassword" />
+        <Spinner
+            android:id="@id/spinner_expiry_month"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.25"
+            android:nextFocusForward="@id/spinner_expiry_year"
+            android:spinnerMode="dialog" />
 
-        </LinearLayout>
+        <Spinner
+            android:id="@id/spinner_expiry_year"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.25"
+            android:nextFocusForward="@id/edit_security_code"
+            android:spinnerMode="dialog" />
+
+        <EditText
+            android:id="@id/edit_security_code"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.5"
+            android:hint="@string/placeholder_security_code"
+            android:inputType="numberPassword" />
 
     </LinearLayout>
 
@@ -125,8 +113,8 @@
         android:layout_marginTop="@dimen/field_separator_margin"
         android:gravity="center"
         android:text="@string/not_available"
-        android:visibility="gone"
-        android:textColor="@android:color/holo_red_light" />
+        android:textColor="@android:color/holo_red_light"
+        android:visibility="gone" />
 
     <Button
         android:id="@id/button_submit"


### PR DESCRIPTION
### Objective

There is an issue for some device (e.g. Samsung). The expiry date spinner doesn't display default expiry date.

![device-2019-07-26-151936](https://user-images.githubusercontent.com/2638321/61937973-4224da00-afba-11e9-8224-287a890d2af3.png)

### Description of change

Seems to be the issue raised from using `simple_spinner_dropdown_item` on the default view. To solved this issue, had changed the default layout to `simple_spinner_item`.

### QA

The default spinner view should show for all device.

![device-2019-07-26-150927](https://user-images.githubusercontent.com/2638321/61937980-47822480-afba-11e9-9e00-40269b3a1e1c.png)


