### PR TITLE
Revise credit card error messages

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -114,6 +114,7 @@ dependencies {
     implementation 'joda-time:joda-time:2.9.2'
     implementation 'com.squareup.okhttp3:okhttp:4.0.1'
     implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "com.google.android.material:material:1.0.0"
     androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     androidTestImplementation 'com.google.guava:guava:19.0'
     testImplementation 'junit:junit:4.12'

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -1,0 +1,20 @@
+package co.omise.android.extensions
+
+import android.content.res.Resources
+import co.omise.android.R
+import co.omise.android.models.APIError
+
+
+fun APIError.getErrorMessage(res: Resources): String {
+    if (code == "invalid_card" && message != null) {
+        return when {
+            message.contains("number") -> res.getString(R.string.error_required_invalid_card_invalid_card_number)
+            message.contains("expiration") -> res.getString(R.string.error_required_invalid_card_invalid_expiry_date)
+            message.contains("name") -> res.getString(R.string.error_required_invalid_card_empty_card_holder_name)
+            message.contains("brand") -> res.getString(R.string.error_required_invalid_card_unsopported_brand)
+            else -> res.getString(R.string.error_required, message)
+        }
+    }
+    return res.getString(R.string.error_required, message)
+}
+

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -5,7 +5,7 @@ import co.omise.android.R
 import co.omise.android.models.APIError
 
 
-fun APIError.getErrorMessage(res: Resources): String = when (code) {
+fun APIError.getMessageFromResources(res: Resources): String = when (code) {
     "invalid_card" -> {
         when {
             message.contains("number") -> res.getString(R.string.error_api_invalid_card_invalid_card_number)

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -5,16 +5,16 @@ import co.omise.android.R
 import co.omise.android.models.APIError
 
 
-fun APIError.getErrorMessage(res: Resources): String {
-    if (code == "invalid_card" && message != null) {
-        return when {
-            message.contains("number") -> res.getString(R.string.error_required_invalid_card_invalid_card_number)
-            message.contains("expiration") -> res.getString(R.string.error_required_invalid_card_invalid_expiry_date)
-            message.contains("name") -> res.getString(R.string.error_required_invalid_card_empty_card_holder_name)
-            message.contains("brand") -> res.getString(R.string.error_required_invalid_card_unsopported_brand)
+fun APIError.getErrorMessage(res: Resources): String = when (code) {
+    "invalid_card" -> {
+        when {
+            message.contains("number") -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
+            message.contains("expiration") -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
+            message.contains("name") -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
+            message.contains("brand") -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
             else -> res.getString(R.string.error_required, message)
         }
     }
-    return res.getString(R.string.error_required, message)
+    "authentication_failure" -> res.getString(R.string.error_api_authentication_failure)
+    else -> res.getString(R.string.error_required, message)
 }
-

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -8,10 +8,10 @@ import co.omise.android.models.APIError
 fun APIError.getMessageFromResources(res: Resources): String = when (code) {
     "invalid_card" -> {
         when {
-            message.contains("number") -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
-            message.contains("expiration") -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
-            message.contains("name") -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
-            message.contains("brand") -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
+            message.isContains("number") -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
+            message.isContains("expiration") -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
+            message.isContains("name") -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
+            message.isContains("brand") -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
             else -> res.getString(R.string.error_required, message)
         }
     }

--- a/sdk/src/main/java/co/omise/android/extensions/StringExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/StringExtensions.kt
@@ -1,0 +1,4 @@
+package co.omise.android.extensions
+
+
+fun String?.isContains(str: String): Boolean = this.toString().contains(str)

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import co.omise.android.R
 import co.omise.android.api.Client
 import co.omise.android.api.RequestListener
+import co.omise.android.extensions.getErrorMessage
 import co.omise.android.extensions.setOnAfterTextChangeListener
 import co.omise.android.extensions.setOnClickListener
 import co.omise.android.models.APIError
@@ -107,7 +108,7 @@ class CreditCardActivity : AppCompatActivity() {
 
             val message = when (throwable) {
                 is IOError -> getString(R.string.error_io, throwable.message)
-                is APIError -> getString(R.string.error_api, throwable.message)
+                is APIError -> throwable.getErrorMessage(resources)
                 else -> getString(R.string.error_unknown, throwable.message)
             }
 

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -3,9 +3,8 @@ package co.omise.android.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
 import android.widget.Button
-import android.widget.TextView
+import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import co.omise.android.R
 import co.omise.android.api.Client
@@ -14,12 +13,13 @@ import co.omise.android.extensions.setOnAfterTextChangeListener
 import co.omise.android.extensions.setOnClickListener
 import co.omise.android.models.APIError
 import co.omise.android.models.Token
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_credit_card.button_submit
 import kotlinx.android.synthetic.main.activity_credit_card.edit_card_name
 import kotlinx.android.synthetic.main.activity_credit_card.edit_card_number
 import kotlinx.android.synthetic.main.activity_credit_card.edit_expiry_date
 import kotlinx.android.synthetic.main.activity_credit_card.edit_security_code
-import kotlinx.android.synthetic.main.activity_credit_card.text_error_message
+import kotlinx.android.synthetic.main.activity_credit_card.layout_credit_card_form
 import java.io.IOError
 
 class CreditCardActivity : AppCompatActivity() {
@@ -29,7 +29,7 @@ class CreditCardActivity : AppCompatActivity() {
     private val expiryDateEdit: ExpiryDateEditText by lazy { edit_expiry_date }
     private val securityCodeEdit: SecurityCodeEditText by lazy { edit_security_code }
     private val submitButton: Button by lazy { button_submit }
-    private val errorMessageText: TextView by lazy { text_error_message }
+    private val containerLayout: LinearLayout by lazy { layout_credit_card_form }
 
     private val editTexts: List<OmiseEditText> by lazy {
         listOf(cardNumberEdit, cardNameEdit, expiryDateEdit, securityCodeEdit)
@@ -86,15 +86,13 @@ class CreditCardActivity : AppCompatActivity() {
         override fun onRequestFailed(throwable: Throwable) {
             enableForm()
 
-            errorMessageText.visibility = View.VISIBLE
-
             val message = when (throwable) {
                 is IOError -> getString(R.string.error_io, throwable.message)
                 is APIError -> getString(R.string.error_api, throwable.message)
                 else -> getString(R.string.error_unknown, throwable.message)
             }
 
-            errorMessageText.text = message
+            Snackbar.make(containerLayout, message, Snackbar.LENGTH_LONG).show()
         }
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -67,7 +67,13 @@ class CreditCardActivity : AppCompatActivity() {
                     try {
                         it.first.validate()
                     } catch (e: InputValidationException.InvalidInputException) {
-                        it.second.text = getString(R.string.error_invalid, it.first.hint)
+                        it.second.text = when (it.first) {
+                            cardNumberEdit -> getString(R.string.error_invalid_card_number)
+                            cardNameEdit -> getString(R.string.error_invalid_card_name)
+                            expiryDateEdit -> getString(R.string.error_invalid_expiry_date)
+                            securityCodeEdit -> getString(R.string.error_invalid_security_code)
+                            else -> null
+                        }
                     } catch (e: InputValidationException.EmptyInputException) {
                         it.second.text = null
                     }

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import co.omise.android.R
 import co.omise.android.api.Client
@@ -20,6 +21,10 @@ import kotlinx.android.synthetic.main.activity_credit_card.edit_card_number
 import kotlinx.android.synthetic.main.activity_credit_card.edit_expiry_date
 import kotlinx.android.synthetic.main.activity_credit_card.edit_security_code
 import kotlinx.android.synthetic.main.activity_credit_card.layout_credit_card_form
+import kotlinx.android.synthetic.main.activity_credit_card.text_card_name_error
+import kotlinx.android.synthetic.main.activity_credit_card.text_card_number_error
+import kotlinx.android.synthetic.main.activity_credit_card.text_expiry_date_error
+import kotlinx.android.synthetic.main.activity_credit_card.text_security_code_error
 import java.io.IOError
 
 class CreditCardActivity : AppCompatActivity() {
@@ -30,9 +35,18 @@ class CreditCardActivity : AppCompatActivity() {
     private val securityCodeEdit: SecurityCodeEditText by lazy { edit_security_code }
     private val submitButton: Button by lazy { button_submit }
     private val containerLayout: LinearLayout by lazy { layout_credit_card_form }
+    private val cardNumberErrorText: TextView by lazy { text_card_number_error }
+    private val cardNameErrorText: TextView by lazy { text_card_name_error }
+    private val expiryDateErrorText: TextView by lazy { text_expiry_date_error }
+    private val securityCodeErrorText: TextView by lazy { text_security_code_error }
 
-    private val editTexts: List<OmiseEditText> by lazy {
-        listOf(cardNumberEdit, cardNameEdit, expiryDateEdit, securityCodeEdit)
+    private val editTexts: List<Pair<OmiseEditText, TextView>> by lazy {
+        listOf(
+                Pair(cardNumberEdit, cardNumberErrorText),
+                Pair(cardNameEdit, cardNameErrorText),
+                Pair(expiryDateEdit, expiryDateErrorText),
+                Pair(securityCodeEdit, securityCodeErrorText)
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -48,21 +62,20 @@ class CreditCardActivity : AppCompatActivity() {
         submitButton.setOnClickListener(::submit)
 
         editTexts.forEach {
-            it.setOnFocusChangeListener { _, hasFocus ->
+            it.first.setOnFocusChangeListener { _, hasFocus ->
                 if (!hasFocus) {
                     try {
-                        it.validate()
+                        it.first.validate()
                     } catch (e: InputValidationException.InvalidInputException) {
-                        it.errorMessage = getString(R.string.error_invalid, it.hint)
+                        it.second.text = getString(R.string.error_invalid, it.first.hint)
                     } catch (e: InputValidationException.EmptyInputException) {
-                        it.errorMessage = null
+                        it.second.text = null
                     }
                 } else {
-                    it.errorMessage = null
+                    it.second.text = null
                 }
             }
-
-            it.setOnAfterTextChangeListener(::updateSubmitButton)
+            it.first.setOnAfterTextChangeListener(::updateSubmitButton)
         }
     }
 
@@ -105,7 +118,7 @@ class CreditCardActivity : AppCompatActivity() {
     }
 
     private fun setFormEnabled(enabled: Boolean) {
-        editTexts.forEach { it.isEnabled = enabled }
+        editTexts.forEach { it.first.isEnabled = enabled }
         submitButton.isEnabled = enabled
     }
 
@@ -136,7 +149,7 @@ class CreditCardActivity : AppCompatActivity() {
     }
 
     private fun updateSubmitButton() {
-        val isFormValid = editTexts.map { it.isValid }
+        val isFormValid = editTexts.map { it.first.isValid }
                 .reduce { acc, b -> acc && b }
         submitButton.isEnabled = isFormValid
     }

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import co.omise.android.R
 import co.omise.android.api.Client
 import co.omise.android.api.RequestListener
-import co.omise.android.extensions.getErrorMessage
+import co.omise.android.extensions.getMessageFromResources
 import co.omise.android.extensions.setOnAfterTextChangeListener
 import co.omise.android.extensions.setOnClickListener
 import co.omise.android.models.APIError
@@ -108,7 +108,7 @@ class CreditCardActivity : AppCompatActivity() {
 
             val message = when (throwable) {
                 is IOError -> getString(R.string.error_io, throwable.message)
-                is APIError -> throwable.getErrorMessage(resources)
+                is APIError -> throwable.getMessageFromResources(resources)
                 else -> getString(R.string.error_unknown, throwable.message)
             }
 

--- a/sdk/src/main/java/co/omise/android/ui/OmiseEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseEditText.kt
@@ -1,17 +1,11 @@
 package co.omise.android.ui
 
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
-import android.text.TextPaint
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatEditText
 
 
 open class OmiseEditText : AppCompatEditText {
-
-    private var errorText: TextPaint? = null
 
     val isValid: Boolean
         get() =
@@ -35,35 +29,6 @@ open class OmiseEditText : AppCompatEditText {
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
 
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-
-
-    var errorMessage: String? = null
-        set(value) {
-            field = value
-            invalidate()
-        }
-
-    init {
-        errorText = TextPaint().apply {
-            color = Color.RED
-            textSize = 14f
-            flags = Paint.ANTI_ALIAS_FLAG
-            textAlign = Paint.Align.LEFT
-        }
-    }
-
-    override fun onDraw(canvas: Canvas?) {
-        super.onDraw(canvas)
-
-        val xPos = paddingLeft.toFloat()
-        val yPos = height - (errorText?.fontMetrics?.bottom ?: 0f)
-        canvas?.drawText(
-                errorMessage ?: "",
-                xPos,
-                yPos,
-                errorText as Paint
-        )
-    }
 }
 
 sealed class InputValidationException : Exception() {

--- a/sdk/src/main/res/layout/activity_credit_card.xml
+++ b/sdk/src/main/res/layout/activity_credit_card.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/form_padding">
+    android:padding="@dimen/form_padding"
+    android:id="@id/layout_credit_card_form">
 
     <TextView
         android:id="@id/text_card_number"
@@ -107,17 +108,6 @@
         </LinearLayout>
 
     </LinearLayout>
-
-
-    <TextView
-        android:id="@+id/text_error_message"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/field_separator_margin"
-        android:gravity="center"
-        android:text="@string/not_available"
-        android:textColor="@android:color/holo_red_light"
-        android:visibility="gone" />
 
     <Button
         android:id="@id/button_submit"

--- a/sdk/src/main/res/layout/activity_credit_card.xml
+++ b/sdk/src/main/res/layout/activity_credit_card.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@id/layout_credit_card_form"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/form_padding"
-    android:id="@id/layout_credit_card_form">
+    android:padding="@dimen/form_padding">
 
     <TextView
         android:id="@id/text_card_number"
@@ -35,6 +35,14 @@
             android:layout_centerVertical="true"
             android:contentDescription="@string/description_brand_logo" />
 
+        <TextView
+            android:id="@id/text_card_number_error"
+            style="@style/OmiseErrorMessage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/edit_card_number"
+            android:text="Invalid input" />
+
     </RelativeLayout>
 
     <TextView
@@ -50,6 +58,13 @@
         android:layout_height="wrap_content"
         android:hint="@string/label_card_name"
         android:nextFocusForward="@id/spinner_expiry_month" />
+
+    <TextView
+        android:id="@id/text_card_name_error"
+        style="@style/OmiseErrorMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Invalid input" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -73,7 +88,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="vertical">
 
                 <co.omise.android.ui.ExpiryDateEditText
                     android:id="@id/edit_expiry_date"
@@ -82,6 +97,14 @@
                     android:hint="@string/hint_expiry_date"
                     android:imeOptions="actionNext"
                     android:nextFocusForward="@id/edit_security_code" />
+
+
+                <TextView
+                    android:id="@id/text_expiry_date_error"
+                    style="@style/OmiseErrorMessage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Invalid input" />
 
             </LinearLayout>
 
@@ -105,6 +128,12 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/placeholder_security_code" />
 
+            <TextView
+                android:id="@id/text_security_code_error"
+                style="@style/OmiseErrorMessage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Invalid input" />
         </LinearLayout>
 
     </LinearLayout>

--- a/sdk/src/main/res/layout/activity_credit_card.xml
+++ b/sdk/src/main/res/layout/activity_credit_card.xml
@@ -40,8 +40,7 @@
             style="@style/OmiseErrorMessage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/edit_card_number"
-            android:text="Invalid input" />
+            android:layout_below="@id/edit_card_number" />
 
     </RelativeLayout>
 
@@ -63,8 +62,7 @@
         android:id="@id/text_card_name_error"
         style="@style/OmiseErrorMessage"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Invalid input" />
+        android:layout_height="wrap_content" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -103,8 +101,7 @@
                     android:id="@id/text_expiry_date_error"
                     style="@style/OmiseErrorMessage"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="Invalid input" />
+                    android:layout_height="wrap_content" />
 
             </LinearLayout>
 
@@ -132,8 +129,7 @@
                 android:id="@id/text_security_code_error"
                 style="@style/OmiseErrorMessage"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Invalid input" />
+                android:layout_height="wrap_content" />
         </LinearLayout>
 
     </LinearLayout>

--- a/sdk/src/main/res/layout/activity_credit_card.xml
+++ b/sdk/src/main/res/layout/activity_credit_card.xml
@@ -12,37 +12,18 @@
         android:layout_height="wrap_content"
         android:text="@string/label_card_number" />
 
-    <RelativeLayout
+    <co.omise.android.ui.CreditCardEditText
+        android:id="@id/edit_card_number"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:hint="@string/label_card_number"
+        android:nextFocusForward="@id/edit_card_name" />
 
-        <co.omise.android.ui.CreditCardEditText
-            android:id="@id/edit_card_number"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentTop="true"
-            android:hint="@string/label_card_number"
-            android:nextFocusForward="@id/edit_card_name" />
-
-        <ImageView
-            android:id="@id/image_card_brand"
-            android:layout_width="wrap_content"
-            android:layout_height="44dp"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:contentDescription="@string/description_brand_logo" />
-
-        <TextView
-            android:id="@id/text_card_number_error"
-            style="@style/OmiseErrorMessage"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/edit_card_number" />
-
-    </RelativeLayout>
+    <TextView
+        android:id="@id/text_card_number_error"
+        style="@style/OmiseErrorMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
     <TextView
         android:id="@id/text_card_name"

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -6,6 +6,10 @@
     <string name="description_brand_logo">カードブランドロゴ</string>
     <string name="error_api">エラー: %1$s</string>
     <string name="error_io">ネットワーク通信エラー, 安定したネット環境で再度試してください. (%1$s)</string>
+    <string name="error_invalid_card_number">クレジットカード番号が無効です</string>
+    <string name="error_invalid_card_name">クレジットカード所有者名が無効です</string>
+    <string name="error_invalid_expiry_date">クレジットカードの有効期限が無効です</string>
+    <string name="error_invalid_security_code">CVVコードが無効です</string>
     <string name="error_invalid">%1$s 無効です。</string>
     <string name="error_required">%1$s は必須です。</string>
     <string name="error_unknown">原因不明のエラーです。. (%1$s)</string>

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -10,8 +10,16 @@
     <string name="error_invalid_card_name">クレジットカード所有者名が無効です</string>
     <string name="error_invalid_expiry_date">クレジットカードの有効期限が無効です</string>
     <string name="error_invalid_security_code">CVVコードが無効です</string>
+
     <string name="error_invalid">%1$s 無効です。</string>
     <string name="error_required">%1$s は必須です。</string>
+
+    <string name="error_api_authentication_failure">認証失敗</string>
+    <string name="error_api_invalid_card_invalid_card_number">無効なカード番号</string>
+    <string name="error_api_invalid_card_invalid_expiry_date">無効なカード有効期限</string>
+    <string name="error_api_invalid_card_empty_card_holder_name">無効なカード所有者名</string>
+    <string name="error_api_invalid_card_unsopported_brand">サポートされていないカード会社です</string>
+
     <string name="error_unknown">原因不明のエラーです。. (%1$s)</string>
     <string name="label_card_name">カード名義</string>
     <string name="label_card_number">カード番号</string>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -6,6 +6,10 @@
     <string name="description_brand_logo">โลโก้บัตรเครดิต</string>
     <string name="error_api">พบข้อผิดพลาด: %1$s</string>
     <string name="error_io">ไม่สามารถเชื่อมต่ออินเตอร์เน็ทได้ กรุณาตรวจสอบและลองใหม่อีกครั้ง (%1$s)</string>
+    <string name="error_invalid_card_number">หมายเลขบัตรไม่ถูกต้อง</string>
+    <string name="error_invalid_card_name">ชื่อผู้ถือบัตรไม่ถูกต้อง</string>
+    <string name="error_invalid_expiry_date">วันหมดอายุของบัตรไม่ถูกต้อง</string>
+    <string name="error_invalid_security_code">หมายเลข CVV ไม่ถูกต้อง</string>
     <string name="error_invalid">%1$sไม่ถูกต้อง</string>
     <string name="error_required">กรุณากรอก%1$s</string>
     <string name="error_unknown">เกิดข้อผิดพลาด (%1$s)</string>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -6,12 +6,20 @@
     <string name="description_brand_logo">โลโก้บัตรเครดิต</string>
     <string name="error_api">พบข้อผิดพลาด: %1$s</string>
     <string name="error_io">ไม่สามารถเชื่อมต่ออินเตอร์เน็ทได้ กรุณาตรวจสอบและลองใหม่อีกครั้ง (%1$s)</string>
+
     <string name="error_invalid_card_number">หมายเลขบัตรไม่ถูกต้อง</string>
     <string name="error_invalid_card_name">ชื่อผู้ถือบัตรไม่ถูกต้อง</string>
     <string name="error_invalid_expiry_date">วันหมดอายุของบัตรไม่ถูกต้อง</string>
     <string name="error_invalid_security_code">หมายเลข CVV ไม่ถูกต้อง</string>
     <string name="error_invalid">%1$sไม่ถูกต้อง</string>
     <string name="error_required">กรุณากรอก%1$s</string>
+
+    <string name="error_api_authentication_failure">การยืนยันตัวตนของร้านค้าไม่ถูกต้อง</string>
+    <string name="error_api_invalid_card_invalid_card_number">หมายเลขบัตรไม่ถูกต้อง</string>
+    <string name="error_api_invalid_card_invalid_expiry_date">วันหมดอายุบัตรไม่ถูกต้อง</string>
+    <string name="error_api_invalid_card_empty_card_holder_name">ชื่อผู้ถือบัตรไม่ถูกต้อง</string>
+    <string name="error_api_invalid_card_unsopported_brand">บัตรเครดิตไม่รองรับ</string>
+
     <string name="error_unknown">เกิดข้อผิดพลาด (%1$s)</string>
     <string name="label_card_name">ชื่อผู้ถือบัตร</string>
     <string name="label_card_number">หมายเลขบัตร</string>

--- a/sdk/src/main/res/values/colors.xml
+++ b/sdk/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="error">#ef3526</color>
+</resources>

--- a/sdk/src/main/res/values/dimen.xml
+++ b/sdk/src/main/res/values/dimen.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="form_padding">16dp</dimen>
     <dimen name="field_separator_margin">16dp</dimen>
+    <dimen name="error_message_start_margin">4dp</dimen>
 </resources>

--- a/sdk/src/main/res/values/dimen.xml
+++ b/sdk/src/main/res/values/dimen.xml
@@ -2,5 +2,5 @@
 <resources>
     <dimen name="form_padding">16dp</dimen>
     <dimen name="field_separator_margin">16dp</dimen>
-    <dimen name="error_message_start_margin">4dp</dimen>
+    <dimen name="error_message_side_margin">4dp</dimen>
 </resources>

--- a/sdk/src/main/res/values/ids.xml
+++ b/sdk/src/main/res/values/ids.xml
@@ -12,4 +12,5 @@
     <item name="text_card_number" type="id" />
     <item name="text_expiry_date" type="id" />
     <item name="text_security_code" type="id" />
+    <item name="layout_credit_card_form" type="id" />
 </resources>

--- a/sdk/src/main/res/values/ids.xml
+++ b/sdk/src/main/res/values/ids.xml
@@ -13,4 +13,8 @@
     <item name="text_expiry_date" type="id" />
     <item name="text_security_code" type="id" />
     <item name="layout_credit_card_form" type="id" />
+    <item name="text_card_number_error" type="id" />
+    <item name="text_card_name_error" type="id" />
+    <item name="text_expiry_date_error" type="id" />
+    <item name="text_security_code_error" type="id" />
 </resources>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -12,10 +12,11 @@
     <string name="error_invalid">%1$s is invalid</string>
     <string name="error_required">%1$s is required</string>
 
-    <string name="error_required_invalid_card_invalid_card_number">Invalid card number</string>
-    <string name="error_required_invalid_card_invalid_expiry_date">Invalid card expiration date</string>
-    <string name="error_required_invalid_card_empty_card_holder_name">Invalid card holder name</string>
-    <string name="error_required_invalid_card_unsopported_brand">Unsupported card brand</string>
+    <string name="error_api_authentication_failure">Authentication failure</string>
+    <string name="error_api_invalid_card_invalid_card_number">Invalid card number</string>
+    <string name="error_api_invalid_card_invalid_expiry_date">Invalid card expiration date</string>
+    <string name="error_api_invalid_card_empty_card_holder_name">Invalid card holder name</string>
+    <string name="error_api_invalid_card_unsopported_brand">Unsupported card brand</string>
 
     <string name="error_unknown">Unknown error occurred. (%1$s)</string>
     <string name="label_card_name">Name on card</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -5,15 +5,19 @@
     <string name="description_brand_logo">Card brand logo</string>
     <string name="error_api">Error: %1$s</string>
     <string name="error_io">Network communication error, please make sure you have a stable internet connection. (%1$s)</string>
+    <string name="error_invalid_card_number">Credit card number is invalid</string>
+    <string name="error_invalid_card_name">Card holder name is invalid</string>
+    <string name="error_invalid_expiry_date">Card expiry date is invalid</string>
+    <string name="error_invalid_security_code">CVV is invalid</string>
     <string name="error_invalid">%1$s is invalid</string>
     <string name="error_required">%1$s is required</string>
     <string name="error_unknown">Unknown error occurred. (%1$s)</string>
     <string name="label_card_name">Name on card</string>
-    <string name="label_card_number">Card Number</string>
+    <string name="label_card_number">Card number</string>
     <string name="label_expiry_date">Expiry date</string>
     <string name="label_security_code">Security code</string>
     <string name="menu_card_io">Scan from Camera</string>
     <string name="title_authorizing_payment">Authorizing Payment</string>
     <string name="placeholder_security_code" translatable="false">CVV</string>
-    <string name="hint_expiry_date">MM/YY</string>
+    <string name="hint_expiry_date" translatable="false">MM/YY</string>
 </resources>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -11,6 +11,12 @@
     <string name="error_invalid_security_code">CVV is invalid</string>
     <string name="error_invalid">%1$s is invalid</string>
     <string name="error_required">%1$s is required</string>
+
+    <string name="error_required_invalid_card_invalid_card_number">Invalid card number</string>
+    <string name="error_required_invalid_card_invalid_expiry_date">Invalid card expiration date</string>
+    <string name="error_required_invalid_card_empty_card_holder_name">Invalid card holder name</string>
+    <string name="error_required_invalid_card_unsopported_brand">Unsupported card brand</string>
+
     <string name="error_unknown">Unknown error occurred. (%1$s)</string>
     <string name="label_card_name">Name on card</string>
     <string name="label_card_number">Card number</string>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -19,10 +19,10 @@
 
     <style name="OmiseErrorMessage" parent="TextAppearance.AppCompat.Caption">
         <item name="android:textColor">@color/error</item>
-        <item name="android:layout_marginLeft">@dimen/error_message_start_margin</item>
-        <item name="android:layout_marginStart">@dimen/error_message_start_margin</item>
-        <item name="android:layout_marginRight">@dimen/error_message_start_margin</item>
-        <item name="android:layout_marginEnd">@dimen/error_message_start_margin</item>
+        <item name="android:layout_marginLeft">@dimen/error_message_side_margin</item>
+        <item name="android:layout_marginStart">@dimen/error_message_side_margin</item>
+        <item name="android:layout_marginRight">@dimen/error_message_side_margin</item>
+        <item name="android:layout_marginEnd">@dimen/error_message_side_margin</item>
     </style>
 
 </resources>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -12,7 +12,6 @@
     </style>
 
     <style name="OmiseFloatingTitle" parent="TextAppearance.AppCompat.Caption">
-        <item name="android:textColor">@android:color/black</item>
     </style>
 
     <style name="OmiseButton" parent="Widget.AppCompat.Button">

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -17,4 +17,10 @@
     <style name="OmiseButton" parent="Widget.AppCompat.Button">
     </style>
 
+    <style name="OmiseErrorMessage" parent="TextAppearance.AppCompat.Caption">
+        <item name="android:textColor">@android:color/holo_red_light</item>
+        <item name="android:layout_marginLeft">@dimen/error_message_start_margin</item>
+        <item name="android:layout_marginStart">@dimen/error_message_start_margin</item>
+    </style>
+
 </resources>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -18,7 +18,7 @@
     </style>
 
     <style name="OmiseErrorMessage" parent="TextAppearance.AppCompat.Caption">
-        <item name="android:textColor">@android:color/holo_red_light</item>
+        <item name="android:textColor">@color/error</item>
         <item name="android:layout_marginLeft">@dimen/error_message_start_margin</item>
         <item name="android:layout_marginStart">@dimen/error_message_start_margin</item>
         <item name="android:layout_marginRight">@dimen/error_message_start_margin</item>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -21,6 +21,8 @@
         <item name="android:textColor">@android:color/holo_red_light</item>
         <item name="android:layout_marginLeft">@dimen/error_message_start_margin</item>
         <item name="android:layout_marginStart">@dimen/error_message_start_margin</item>
+        <item name="android:layout_marginRight">@dimen/error_message_start_margin</item>
+        <item name="android:layout_marginEnd">@dimen/error_message_start_margin</item>
     </style>
 
 </resources>

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -115,6 +115,24 @@ class CreditCardActivityTest {
         val result = scenario.result
         assertEquals(RESULT_CANCELED, result.resultCode)
     }
+
+    @Test
+    fun errorMessages_showErrorMessage() {
+        onView(withId(R.id.edit_card_number)).perform(typeText("42424242"), pressImeActionButton())
+
+        onView(withId(R.id.text_card_number_error)).check(matches(allOf(withText("Card Number is invalid"))))
+
+
+        onView(withId(R.id.edit_expiry_date)).perform(typeText("123"), pressImeActionButton())
+
+        onView(withId(R.id.text_expiry_date_error)).check(matches(allOf(withText("MM/YY is invalid"))))
+
+
+        onView(withId(R.id.edit_security_code)).perform(typeText("12"), pressImeActionButton())
+        onView(withId(R.id.edit_card_number)).perform(click())
+
+        onView(withId(R.id.text_security_code_error)).check(matches(allOf(withText("CVV is invalid"))))
+    }
 }
 
 private fun typeNumberText(numberText: String): ViewAction =

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -120,18 +120,18 @@ class CreditCardActivityTest {
     fun errorMessages_showErrorMessage() {
         onView(withId(R.id.edit_card_number)).perform(typeText("42424242"), pressImeActionButton())
 
-        onView(withId(R.id.text_card_number_error)).check(matches(allOf(withText("Card Number is invalid"))))
+        onView(withId(R.id.text_card_number_error)).check(matches(allOf(withText(R.string.error_invalid_card_number))))
 
 
         onView(withId(R.id.edit_expiry_date)).perform(typeText("123"), pressImeActionButton())
 
-        onView(withId(R.id.text_expiry_date_error)).check(matches(allOf(withText("MM/YY is invalid"))))
+        onView(withId(R.id.text_expiry_date_error)).check(matches(allOf(withText(R.string.error_invalid_expiry_date))))
 
 
         onView(withId(R.id.edit_security_code)).perform(typeText("12"), pressImeActionButton())
         onView(withId(R.id.edit_card_number)).perform(click())
 
-        onView(withId(R.id.text_security_code_error)).check(matches(allOf(withText("CVV is invalid"))))
+        onView(withId(R.id.text_security_code_error)).check(matches(allOf(withText(R.string.error_invalid_security_code))))
     }
 }
 

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
 import co.omise.android.models.APIError
+import co.omise.android.models.Serializer
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,100 +14,106 @@ import org.junit.runner.RunWith
 class APIErrorExtensionsTest {
 
     private val resources = ApplicationProvider.getApplicationContext<Application>().resources
-
+    private val serializer = Serializer()
     @Test
     fun getMessageFromResources_invalidCardNumber() {
-        val error = APIError("""
+        val response = """
            {
               "object": "error",
               "location": "https://www.omise.co/api-errors#invalid-card",
               "code": "invalid_card",
               "message": "number can't be blank and brand not supported (unknown)"
             }
-        """.trimIndent())
+        """.trimIndent()
+        val error = serializer.deserialize(response.byteInputStream(), APIError::class.java)
 
-        val actualError = error.getMessageFromResources(resources)
+        val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_card_number), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_card_number), actualMessage)
     }
 
     @Test
     fun getMessageFromResources_invalidExpiryDate() {
-        val error = APIError("""
+        val response = """
            {
               "object": "error",
               "location": "https://www.omise.co/api-errors#invalid-card",
               "code": "invalid_card",
               "message": "expiration date cannot be in the past"
             }
-        """.trimIndent())
+        """.trimIndent()
+        val error = serializer.deserialize(response.byteInputStream(), APIError::class.java)
 
-        val actualError = error.getMessageFromResources(resources)
+        val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_expiry_date), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_expiry_date), actualMessage)
     }
 
     @Test
     fun getMessageFromResources_emptyCardHolderName() {
-        val error = APIError("""
+        val response = """
             {
               "object": "error",
               "location": "https://www.omise.co/api-errors#invalid-card",
               "code": "invalid_card",
               "message": "name can't be blank"
             }
-        """.trimIndent())
+        """.trimIndent()
+        val error = serializer.deserialize(response.byteInputStream(), APIError::class.java)
 
-        val actualError = error.getMessageFromResources(resources)
+        val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_api_invalid_card_empty_card_holder_name), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_empty_card_holder_name), actualMessage)
     }
 
     @Test
     fun getMessageFromResources_unsupportedBrand() {
-        val error = APIError("""
+        val response = """
             {
               "object": "error",
               "location": "https://www.omise.co/api-errors#invalid-card",
               "code": "invalid_card",
               "message": "brand not supported (unknown)"
             }
-        """.trimIndent())
+        """.trimIndent()
+        val error = serializer.deserialize(response.byteInputStream(), APIError::class.java)
 
-        val actualError = error.getMessageFromResources(resources)
+        val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_api_invalid_card_unsopported_brand), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_unsopported_brand), actualMessage)
     }
 
     @Test
     fun getMessageFromResources_otherError() {
-        val error = APIError("""
+        val response = """
             {
               "object": "error",
               "location": "https://www.omise.co/api-errors#invalid-card",
               "code": "invalid_card",
               "message": "something when wrong"
             }
-        """.trimIndent())
+        """.trimIndent()
+        val error = serializer.deserialize(response.byteInputStream(), APIError::class.java)
 
-        val actualError = error.getMessageFromResources(resources)
+        val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_required, "something when wrong"), actualError)
+        assertEquals(resources.getString(R.string.error_required, "something when wrong"), actualMessage)
     }
 
     @Test
     fun getMessageFromResources_authenticationFailure() {
-        val error = APIError("""
+        val response = """
             {
               "object": "error",
               "location": "https://www.omise.co/api-errors#authentication-failure",
               "code": "authentication_failure",
               "message": "authentication failed"
             }
-        """.trimIndent())
+        """.trimIndent()
+        val error = serializer.deserialize(response.byteInputStream(), APIError::class.java)
 
-        val actualError = error.getMessageFromResources(resources)
+        val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_api_authentication_failure), actualError)
+        assertEquals(resources.getString(R.string.error_api_authentication_failure), actualMessage)
     }
 }

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -1,0 +1,97 @@
+package co.omise.android.extensions
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import co.omise.android.R
+import co.omise.android.models.APIError
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class APIErrorExtensionsTest {
+
+    private val resources = ApplicationProvider.getApplicationContext<Application>().resources
+
+    @Test
+    fun getErrorMessage_invalidCardNumber() {
+        val error = APIError("""
+           {
+              "object": "error",
+              "location": "https://www.omise.co/api-errors#invalid-card",
+              "code": "invalid_card",
+              "message": "number can't be blank and brand not supported (unknown)"
+            }
+        """.trimIndent())
+
+        val actualError = error.getErrorMessage(resources)
+
+        assertEquals(resources.getString(R.string.error_required_invalid_card_invalid_card_number), actualError)
+    }
+
+    @Test
+    fun getErrorMessage_invalidExpiryDate() {
+        val error = APIError("""
+           {
+              "object": "error",
+              "location": "https://www.omise.co/api-errors#invalid-card",
+              "code": "invalid_card",
+              "message": "expiration date cannot be in the past"
+            }
+        """.trimIndent())
+
+        val actualError = error.getErrorMessage(resources)
+
+        assertEquals(resources.getString(R.string.error_required_invalid_card_invalid_expiry_date), actualError)
+    }
+
+    @Test
+    fun getErrorMessage_emptyCardHolderName() {
+        val error = APIError("""
+            {
+              "object": "error",
+              "location": "https://www.omise.co/api-errors#invalid-card",
+              "code": "invalid_card",
+              "message": "name can't be blank"
+            }
+        """.trimIndent())
+
+        val actualError = error.getErrorMessage(resources)
+
+        assertEquals(resources.getString(R.string.error_required_invalid_card_empty_card_holder_name), actualError)
+    }
+
+    @Test
+    fun getErrorMessage_unsupportedBrand() {
+        val error = APIError("""
+            {
+              "object": "error",
+              "location": "https://www.omise.co/api-errors#invalid-card",
+              "code": "invalid_card",
+              "message": "brand not supported (unknown)"
+            }
+        """.trimIndent())
+
+        val actualError = error.getErrorMessage(resources)
+
+        assertEquals(resources.getString(R.string.error_required_invalid_card_unsopported_brand), actualError)
+    }
+
+    @Test
+    fun getErrorMessage_otherError() {
+        val error = APIError("""
+            {
+              "object": "error",
+              "location": "https://www.omise.co/api-errors#invalid-card",
+              "code": "invalid_card",
+              "message": "something when wrong"
+            }
+        """.trimIndent())
+
+        val actualError = error.getErrorMessage(resources)
+
+        assertEquals(resources.getString(R.string.error_required, "something when wrong"), actualError)
+    }
+}

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -28,7 +28,7 @@ class APIErrorExtensionsTest {
 
         val actualError = error.getErrorMessage(resources)
 
-        assertEquals(resources.getString(R.string.error_required_invalid_card_invalid_card_number), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_card_number), actualError)
     }
 
     @Test
@@ -44,7 +44,7 @@ class APIErrorExtensionsTest {
 
         val actualError = error.getErrorMessage(resources)
 
-        assertEquals(resources.getString(R.string.error_required_invalid_card_invalid_expiry_date), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_expiry_date), actualError)
     }
 
     @Test
@@ -60,7 +60,7 @@ class APIErrorExtensionsTest {
 
         val actualError = error.getErrorMessage(resources)
 
-        assertEquals(resources.getString(R.string.error_required_invalid_card_empty_card_holder_name), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_empty_card_holder_name), actualError)
     }
 
     @Test
@@ -76,7 +76,7 @@ class APIErrorExtensionsTest {
 
         val actualError = error.getErrorMessage(resources)
 
-        assertEquals(resources.getString(R.string.error_required_invalid_card_unsopported_brand), actualError)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_unsopported_brand), actualError)
     }
 
     @Test
@@ -93,5 +93,21 @@ class APIErrorExtensionsTest {
         val actualError = error.getErrorMessage(resources)
 
         assertEquals(resources.getString(R.string.error_required, "something when wrong"), actualError)
+    }
+
+    @Test
+    fun getErrorMessage_authenticationFailure() {
+        val error = APIError("""
+            {
+              "object": "error",
+              "location": "https://www.omise.co/api-errors#authentication-failure",
+              "code": "authentication_failure",
+              "message": "authentication failed"
+            }
+        """.trimIndent())
+
+        val actualError = error.getErrorMessage(resources)
+
+        assertEquals(resources.getString(R.string.error_api_authentication_failure), actualError)
     }
 }

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -15,7 +15,7 @@ class APIErrorExtensionsTest {
     private val resources = ApplicationProvider.getApplicationContext<Application>().resources
 
     @Test
-    fun getErrorMessage_invalidCardNumber() {
+    fun getMessageFromResources_invalidCardNumber() {
         val error = APIError("""
            {
               "object": "error",
@@ -25,13 +25,13 @@ class APIErrorExtensionsTest {
             }
         """.trimIndent())
 
-        val actualError = error.getErrorMessage(resources)
+        val actualError = error.getMessageFromResources(resources)
 
         assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_card_number), actualError)
     }
 
     @Test
-    fun getErrorMessage_invalidExpiryDate() {
+    fun getMessageFromResources_invalidExpiryDate() {
         val error = APIError("""
            {
               "object": "error",
@@ -41,13 +41,13 @@ class APIErrorExtensionsTest {
             }
         """.trimIndent())
 
-        val actualError = error.getErrorMessage(resources)
+        val actualError = error.getMessageFromResources(resources)
 
         assertEquals(resources.getString(R.string.error_api_invalid_card_invalid_expiry_date), actualError)
     }
 
     @Test
-    fun getErrorMessage_emptyCardHolderName() {
+    fun getMessageFromResources_emptyCardHolderName() {
         val error = APIError("""
             {
               "object": "error",
@@ -57,13 +57,13 @@ class APIErrorExtensionsTest {
             }
         """.trimIndent())
 
-        val actualError = error.getErrorMessage(resources)
+        val actualError = error.getMessageFromResources(resources)
 
         assertEquals(resources.getString(R.string.error_api_invalid_card_empty_card_holder_name), actualError)
     }
 
     @Test
-    fun getErrorMessage_unsupportedBrand() {
+    fun getMessageFromResources_unsupportedBrand() {
         val error = APIError("""
             {
               "object": "error",
@@ -73,13 +73,13 @@ class APIErrorExtensionsTest {
             }
         """.trimIndent())
 
-        val actualError = error.getErrorMessage(resources)
+        val actualError = error.getMessageFromResources(resources)
 
         assertEquals(resources.getString(R.string.error_api_invalid_card_unsopported_brand), actualError)
     }
 
     @Test
-    fun getErrorMessage_otherError() {
+    fun getMessageFromResources_otherError() {
         val error = APIError("""
             {
               "object": "error",
@@ -89,13 +89,13 @@ class APIErrorExtensionsTest {
             }
         """.trimIndent())
 
-        val actualError = error.getErrorMessage(resources)
+        val actualError = error.getMessageFromResources(resources)
 
         assertEquals(resources.getString(R.string.error_required, "something when wrong"), actualError)
     }
 
     @Test
-    fun getErrorMessage_authenticationFailure() {
+    fun getMessageFromResources_authenticationFailure() {
         val error = APIError("""
             {
               "object": "error",
@@ -105,7 +105,7 @@ class APIErrorExtensionsTest {
             }
         """.trimIndent())
 
-        val actualError = error.getErrorMessage(resources)
+        val actualError = error.getMessageFromResources(resources)
 
         assertEquals(resources.getString(R.string.error_api_authentication_failure), actualError)
     }

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -5,9 +5,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
 import co.omise.android.models.APIError
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)

--- a/sdk/src/test/java/co/omise/android/ui/OmiseEditTextTest.kt
+++ b/sdk/src/test/java/co/omise/android/ui/OmiseEditTextTest.kt
@@ -2,8 +2,6 @@ package co.omise.android.ui
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -11,19 +9,6 @@ import org.junit.runner.RunWith
 class OmiseEditTextTest {
 
     private val editText = OmiseEditText(ApplicationProvider.getApplicationContext())
-
-    @Test
-    fun errorMessage_setErrorMessage() {
-        editText.errorMessage = "Invalid input."
-        assertEquals("Invalid input.", editText.errorMessage)
-    }
-
-    @Test
-    fun errorMessage_clearErrorMessage() {
-        editText.errorMessage = "Invalid input."
-        editText.errorMessage = null
-        assertNull(editText.errorMessage)
-    }
 
     @Test(expected = InputValidationException.EmptyInputException::class)
     fun validate_emptyValue() {

--- a/sdk/src/test/resources/data/objects/error_object.json
+++ b/sdk/src/test/resources/data/objects/error_object.json
@@ -1,0 +1,6 @@
+{
+  "object": "error",
+  "location": "https://www.omise.co/api-errors#authentication-failure",
+  "code": "authentication_failure",
+  "message": "authentication failed"
+}


### PR DESCRIPTION
### Objective

**Invalid input error**

As the team discussed, we decided to separate the error text from `OmiseEditText`.

**API request error**

 Follow the new design. It changes to use `Snackbar` to show the error message from API request error.

### Description of Changes

**Invalid input error**

To show the invalid input error on CreditCardActivity, added the TextViews under the EditTexts. And deleted the error text from `OmiseEditText`.

**API request error**

Show error message on Snackbar when creating a token return an error from request.

### QA 

When the user enter invalid inputs or got error from request the CreditCardActivity will show error messages follow the image.

![revise-error-messages](https://user-images.githubusercontent.com/2638321/62199230-53e8f180-b3ad-11e9-86cd-dbca8a5b2ce1.png)
