### PR TITLE
Remove certificate pinning

### DIFF
--- a/sdk/src/main/java/co/omise/android/Client.java
+++ b/sdk/src/main/java/co/omise/android/Client.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.X509TrustManager;
 
-import okhttp3.CertificatePinner;
 import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.Interceptor;
@@ -72,14 +71,7 @@ public class Client {
         return builder
                 .addInterceptor(buildInterceptor())
                 .connectionSpecs(Collections.singletonList(spec))
-                .certificatePinner(buildCertificatePinner())
                 .readTimeout(60, TimeUnit.SECONDS)
-                .build();
-    }
-
-    private CertificatePinner buildCertificatePinner() {
-        return new CertificatePinner.Builder()
-                .add("vault.omise.co", "sha256/maqNsxEnwszR+xCmoGUiV636PvSM5zvBIBuupBn9AB8=")
                 .build();
     }
 


### PR DESCRIPTION
In the old way we used the certificate pinning to prevent Man in the Middle(MITM) attack to secure our requests. OSes nowadays there's new way to help to prevent MITM attack.

So, we decided to remove the certificate pinning from build-in library and use the default certificate
that provide from the OSes or their system instead.