### PR TITLE
Model immutability

### DIFF
--- a/sdk/src/main/java/co/omise/android/models/Capability.kt
+++ b/sdk/src/main/java/co/omise/android/models/Capability.kt
@@ -14,11 +14,11 @@ import okhttp3.HttpUrl
  */
 @Parcelize
 data class Capability(
-        var banks: List<String>? = null,
+        val banks: List<String>? = null,
         @field:JsonProperty("payment_methods")
-        var paymentMethods: List<PaymentMethod>? = null,
+        val paymentMethods: List<PaymentMethod>? = null,
         @field:JsonProperty("zero_interest_installments")
-        var zeroInterestInstallments: Boolean = false
+        val zeroInterestInstallments: Boolean = false
 ) : Model(), Parcelable {
 
     /**

--- a/sdk/src/main/java/co/omise/android/models/Card.kt
+++ b/sdk/src/main/java/co/omise/android/models/Card.kt
@@ -11,21 +11,21 @@ import kotlinx.android.parcel.Parcelize
  */
 @Parcelize
 data class Card(
-        var country: String? = null,
-        var city: String? = null,
+        val country: String? = null,
+        val city: String? = null,
         @field:JsonProperty("postal_code")
-        var postalCode: String? = null,
-        var financing: String? = null,
+        val postalCode: String? = null,
+        val financing: String? = null,
         @field:JsonProperty("last_digits")
-        var lastDigits: String? = null,
-        var brand: String? = null,
+        val lastDigits: String? = null,
+        val brand: String? = null,
         @field:JsonProperty("expiration_month")
-        var expirationMonth: Int = 0,
+        val expirationMonth: Int = 0,
         @field:JsonProperty("expiration_year")
-        var expirationYear: Int = 0,
-        var fingerprint: String? = null,
-        var name: String? = null,
+        val expirationYear: Int = 0,
+        val fingerprint: String? = null,
+        val name: String? = null,
         @field:JsonProperty("security_code_check")
-        var securityCodeCheck: Boolean = false,
-        var bank: String? = null
+        val securityCodeCheck: Boolean = false,
+        val bank: String? = null
 ) : Model(), Parcelable

--- a/sdk/src/main/java/co/omise/android/models/Model.kt
+++ b/sdk/src/main/java/co/omise/android/models/Model.kt
@@ -12,15 +12,15 @@ import org.joda.time.DateTime
 @Parcelize
 open class Model(
         @field:JsonProperty("object")
-        var modelObject: String? = null,
-        var id: String? = null,
+        val modelObject: String? = null,
+        val id: String? = null,
         @field:JsonProperty("livemode")
-        var livemode: Boolean = false,
-        var location: String? = null,
+        val livemode: Boolean = false,
+        val location: String? = null,
         @field:JsonProperty("created_at")
-        var created: DateTime? = null,
+        val created: DateTime? = null,
         @field:JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        var deleted: Boolean = false
+        val deleted: Boolean = false
 ) : Parcelable {
 
     override fun equals(other: Any?): Boolean {
@@ -31,5 +31,15 @@ open class Model(
                 otherModel.location == location &&
                 otherModel.created?.millis == created?.millis &&
                 otherModel.deleted == deleted
+    }
+
+    override fun hashCode(): Int {
+        var result = modelObject?.hashCode() ?: 0
+        result = 31 * result + (id?.hashCode() ?: 0)
+        result = 31 * result + livemode.hashCode()
+        result = 31 * result + (location?.hashCode() ?: 0)
+        result = 31 * result + (created?.hashCode() ?: 0)
+        result = 31 * result + deleted.hashCode()
+        return result
     }
 }

--- a/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
+++ b/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
@@ -6,10 +6,10 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class PaymentMethod(
-        var name: String? = null,
-        var currencies: List<String>? = null,
+        val name: String? = null,
+        val currencies: List<String>? = null,
         @field:JsonProperty("card_brands")
-        var cardBrands: List<String>? = null,
+        val cardBrands: List<String>? = null,
         @field:JsonProperty("installment_terms")
-        var installmentTerms: List<Int>? = null
+        val installmentTerms: List<Int>? = null
 ) : Model(), Parcelable

--- a/sdk/src/main/java/co/omise/android/models/References.kt
+++ b/sdk/src/main/java/co/omise/android/models/References.kt
@@ -13,14 +13,14 @@ import org.joda.time.DateTime
 @Parcelize
 data class References(
         @field:JsonProperty("va_code")
-        var vaCode: String? = null,
+        val vaCode: String? = null,
         @field:JsonProperty("omise_tax_id")
-        var omiseTaxId: String? = null,
+        val omiseTaxId: String? = null,
         @field:JsonProperty("reference_number_1")
-        var referenceNumber1: String? = null,
+        val referenceNumber1: String? = null,
         @field:JsonProperty("reference_number_2")
-        var referenceNumber2: String? = null,
-        var barcode: String? = null,
+        val referenceNumber2: String? = null,
+        val barcode: String? = null,
         @field:JsonProperty("expires_at")
-        var expiresAt: DateTime? = null
+        val expiresAt: DateTime? = null
 ) : Model(), Parcelable

--- a/sdk/src/main/java/co/omise/android/models/Source.kt
+++ b/sdk/src/main/java/co/omise/android/models/Source.kt
@@ -21,22 +21,22 @@ import java.io.IOException
 data class Source(
         var type: SourceType = SourceType.Unknown,
         var flow: FlowType = FlowType.Unknown,
-        var amount: Long = 0,
-        var currency: String? = null,
-        var barcode: String? = null,
-        var references: References? = null,
+        val amount: Long = 0,
+        val currency: String? = null,
+        val barcode: String? = null,
+        val references: References? = null,
         @field:JsonProperty("store_id")
-        var storeId: String? = null,
+        val storeId: String? = null,
         @field:JsonProperty("store_name")
-        var storeName: String? = null,
+        val storeName: String? = null,
         @field:JsonProperty("terminal_id")
-        var terminalId: String? = null,
-        var name: String? = null,
-        var email: String? = null,
+        val terminalId: String? = null,
+        val name: String? = null,
+        val email: String? = null,
         @field:JsonProperty("phone_number")
-        var phoneNumber: String? = null,
+        val phoneNumber: String? = null,
         @field:JsonProperty("installment_term")
-        var installmentTerm: Int = 0
+        val installmentTerm: Int = 0
 ) : Model(), Parcelable {
 
     /**

--- a/sdk/src/main/java/co/omise/android/models/Token.kt
+++ b/sdk/src/main/java/co/omise/android/models/Token.kt
@@ -16,8 +16,8 @@ import java.io.IOException
  */
 @Parcelize
 data class Token(
-        var used: Boolean = false,
-        var card: Card? = null
+        val used: Boolean = false,
+        val card: Card? = null
 ) : Model(), Parcelable {
 
     /**

--- a/sdk/src/test/java/co/omise/android/ParcelableTest.kt
+++ b/sdk/src/test/java/co/omise/android/ParcelableTest.kt
@@ -63,13 +63,11 @@ class ParcelableTest {
     @Test
     fun capabilityParceling_success() {
         val paymentMethodList: List<PaymentMethod> = (1..10).map {
-            PaymentMethod().apply {
-                id = "id-$it"
-                name = "Method no: $it"
-                currencies = listOf("thb, usd, myr, sgd, jpy")
-                cardBrands = listOf("VISA", "MASTER", "LASER")
-                installmentTerms = listOf(1, 2, 4, 6)
-            }
+            PaymentMethod(
+                    "Method no: $it",
+                    listOf("thb, usd, myr, sgd, jpy"),
+                    listOf("VISA", "MASTER", "LASER"),
+                    listOf(1, 2, 4, 6))
         }
         val capability = Capability(
                 mutableListOf("a", "b", "c", "d"),


### PR DESCRIPTION
**TASK**=>T16075

**SUMMARY**
Small PR to make all the data models in the SDK immutable.

🦑 **NOTE** 🦑
 It was initially planned to also remove initial values from the properties and make them non-nullable as a result, but that caused crashes due to internal issues in `Jackson`, so they are kept the way they are till a workaround for that issue can be found.