### PR TITLE
Create payment from credit card

### DIFF
--- a/app/src/main/java/co/omise/android/example/CheckoutActivity.java
+++ b/app/src/main/java/co/omise/android/example/CheckoutActivity.java
@@ -12,6 +12,7 @@ import com.squareup.picasso.Picasso;
 
 import co.omise.android.models.Token;
 import co.omise.android.ui.CreditCardActivity;
+import co.omise.android.ui.OmiseActivity;
 
 public class CheckoutActivity extends BaseActivity implements View.OnClickListener {
     public static final String OMISE_PKEY = "pkey_test_52d6po3fvio2w6tefpb";
@@ -48,7 +49,7 @@ public class CheckoutActivity extends BaseActivity implements View.OnClickListen
     @Override
     public void onClick(View v) {
         Intent intent = new Intent(this, CreditCardActivity.class);
-        intent.putExtra(CreditCardActivity.EXTRA_PKEY, OMISE_PKEY);
+        intent.putExtra(OmiseActivity.EXTRA_PKEY, OMISE_PKEY);
         startActivityForResult(intent, REQUEST_CC);
     }
 
@@ -61,7 +62,7 @@ public class CheckoutActivity extends BaseActivity implements View.OnClickListen
                     return;
                 }
 
-                Token token = data.getParcelableExtra(CreditCardActivity.EXTRA_TOKEN_OBJECT);
+                Token token = data.getParcelableExtra(OmiseActivity.EXTRA_TOKEN_OBJECT);
 
                 Intent intent = new Intent(this, ReceiptActivity.class);
                 intent.putExtra(ReceiptActivity.EXTRA_PRODUCT_ID, productId());

--- a/app/src/main/java/co/omise/android/example/MainActivity.java
+++ b/app/src/main/java/co/omise/android/example/MainActivity.java
@@ -16,15 +16,12 @@ import co.omise.android.api.Request;
 import co.omise.android.api.RequestListener;
 import co.omise.android.models.Capability;
 import co.omise.android.ui.AuthorizingPaymentActivity;
+import co.omise.android.ui.OmiseActivity;
 import co.omise.android.ui.PaymentCreatorActivity;
 
 import static co.omise.android.AuthorizingPaymentURLVerifier.EXTRA_AUTHORIZED_URLSTRING;
 import static co.omise.android.AuthorizingPaymentURLVerifier.EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS;
 import static co.omise.android.AuthorizingPaymentURLVerifier.EXTRA_RETURNED_URLSTRING;
-import static co.omise.android.ui.PaymentCreatorActivity.EXTRA_AMOUNT;
-import static co.omise.android.ui.PaymentCreatorActivity.EXTRA_CAPABILITY;
-import static co.omise.android.ui.PaymentCreatorActivity.EXTRA_CURRENCY;
-import static co.omise.android.ui.PaymentCreatorActivity.EXTRA_PKEY;
 
 public class MainActivity extends BaseActivity implements AdapterView.OnItemClickListener {
     private ProductListAdapter listAdapter = null;
@@ -53,10 +50,10 @@ public class MainActivity extends BaseActivity implements AdapterView.OnItemClic
             @Override
             public void onRequestSucceed(@NotNull Capability model) {
                 Intent intent = new Intent(MainActivity.this, PaymentCreatorActivity.class);
-                intent.putExtra(EXTRA_PKEY, PUBLIC_KEY);
-                intent.putExtra(EXTRA_AMOUNT, 50000);
-                intent.putExtra(EXTRA_CURRENCY, "thb");
-                intent.putExtra(EXTRA_CAPABILITY, model);
+                intent.putExtra(OmiseActivity.EXTRA_PKEY, PUBLIC_KEY);
+                intent.putExtra(OmiseActivity.EXTRA_AMOUNT, 50000);
+                intent.putExtra(OmiseActivity.EXTRA_CURRENCY, "thb");
+                intent.putExtra(OmiseActivity.EXTRA_CAPABILITY, model);
                 startActivityForResult(intent, PAYMENT_CREATOR_REQUEST_CODE);
             }
 
@@ -101,6 +98,8 @@ public class MainActivity extends BaseActivity implements AdapterView.OnItemClic
         if (requestCode == MainActivity.AUTHORIZING_PAYMENT_REQUEST_CODE && resultCode == RESULT_OK) {
             String url = data.getStringExtra(EXTRA_RETURNED_URLSTRING);
             Toast.makeText(getApplicationContext(), url, Toast.LENGTH_LONG).show();
+        } else if (requestCode == PAYMENT_CREATOR_REQUEST_CODE && resultCode == RESULT_OK) {
+            Toast.makeText(getApplicationContext(), data.getStringExtra(OmiseActivity.EXTRA_TOKEN), Toast.LENGTH_LONG).show();
         } else if (resultCode == RESULT_CANCELED) {
             Toast.makeText(getApplicationContext(), "Canceled", Toast.LENGTH_LONG).show();
         }

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -8,7 +8,6 @@ import android.widget.Button
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
 import co.omise.android.CardNumber
 import co.omise.android.R
 import co.omise.android.api.Client
@@ -33,7 +32,7 @@ import kotlinx.android.synthetic.main.activity_credit_card.text_expiry_date_erro
 import kotlinx.android.synthetic.main.activity_credit_card.text_security_code_error
 import java.io.IOError
 
-class CreditCardActivity : AppCompatActivity() {
+class CreditCardActivity : OmiseActivity() {
 
     private val cardNumberEdit: CreditCardEditText by lazy { edit_card_number }
     private val cardNameEdit: CardNameEditText by lazy { edit_card_name }
@@ -185,14 +184,5 @@ class CreditCardActivity : AppCompatActivity() {
         val brand = CardNumber.brand(cardNumberEdit.cardNumber)
         val dialog = SecurityCodeTooltipDialogFragment.newInstant(brand)
         dialog.show(supportFragmentManager, null)
-    }
-
-    companion object {
-        // input
-        const val EXTRA_PKEY = "CreditCardActivity.publicKey"
-
-        const val EXTRA_TOKEN = "CreditCardActivity.token"
-        const val EXTRA_TOKEN_OBJECT = "CreditCardActivity.tokenObject"
-        const val EXTRA_CARD_OBJECT = "CreditCardActivity.cardObject"
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
@@ -1,5 +1,7 @@
 package co.omise.android.ui
 
+import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 
 
@@ -15,5 +17,10 @@ abstract class OmiseActivity : AppCompatActivity() {
         const val EXTRA_TOKEN = "OmiseActivity.token"
         const val EXTRA_TOKEN_OBJECT = "OmiseActivity.tokenObject"
         const val EXTRA_CARD_OBJECT = "OmiseActivity.cardObject"
+    }
+
+    @VisibleForTesting
+    fun performActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        onActivityResult(requestCode, resultCode, data)
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
@@ -6,11 +6,14 @@ import androidx.appcompat.app.AppCompatActivity
 abstract class OmiseActivity : AppCompatActivity() {
 
     companion object {
-        const val EXTRA_PKEY = "OmiseActivity.pkey"
+        const val EXTRA_PKEY = "OmiseActivity.publicKey"
         const val EXTRA_SOURCE_OBJECT = "OmiseActivity.sourceObject"
-        const val EXTRA_TOKEN_OBJECT = "OmiseActivity.tokenObject"
         const val EXTRA_AMOUNT = "OmiseActivity.amount"
         const val EXTRA_CURRENCY = "OmiseActivity.currency"
         const val EXTRA_CAPABILITY = "OmiseActivity.capability"
+
+        const val EXTRA_TOKEN = "OmiseActivity.token"
+        const val EXTRA_TOKEN_OBJECT = "OmiseActivity.tokenObject"
+        const val EXTRA_CARD_OBJECT = "OmiseActivity.cardObject"
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -3,6 +3,7 @@ package co.omise.android.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import co.omise.android.R
 import co.omise.android.models.Capability
@@ -16,7 +17,8 @@ class PaymentCreatorActivity : OmiseActivity() {
     private val currency: String by lazy { intent.getStringExtra(EXTRA_CURRENCY) }
     private val capability: Capability by lazy { intent.getParcelableExtra<Capability>(EXTRA_CAPABILITY) }
 
-    private val navigation: PaymentCreatorNavigation by lazy {
+    @VisibleForTesting
+    val navigation: PaymentCreatorNavigation by lazy {
         PaymentCreatorNavigationImpl(this, pkey, REQUEST_CREDIT_CARD)
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -1,10 +1,13 @@
 package co.omise.android.ui
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import co.omise.android.R
 import co.omise.android.models.Capability
+import co.omise.android.models.Token
+import co.omise.android.ui.OmiseActivity.Companion.EXTRA_PKEY
 
 class PaymentCreatorActivity : OmiseActivity() {
 
@@ -13,7 +16,9 @@ class PaymentCreatorActivity : OmiseActivity() {
     private val currency: String by lazy { intent.getStringExtra(EXTRA_CURRENCY) }
     private val capability: Capability by lazy { intent.getParcelableExtra<Capability>(EXTRA_CAPABILITY) }
 
-    private val navigation: PaymentCreatorNavigation by lazy { PaymentCreatorNavigationImpl(this) }
+    private val navigation: PaymentCreatorNavigation by lazy {
+        PaymentCreatorNavigationImpl(this, pkey, REQUEST_CREDIT_CARD)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,6 +39,25 @@ class PaymentCreatorActivity : OmiseActivity() {
             super.onBackPressed()
         }
     }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == REQUEST_CREDIT_CARD && resultCode == Activity.RESULT_OK) {
+            val token = data?.getParcelableExtra<Token>(EXTRA_TOKEN_OBJECT)
+            val intent = Intent().apply {
+                putExtra(EXTRA_TOKEN, token?.id)
+                putExtra(EXTRA_TOKEN_OBJECT, token)
+                putExtra(EXTRA_CARD_OBJECT, token?.card)
+            }
+            setResult(Activity.RESULT_OK, intent)
+            finish()
+        }
+    }
+
+    companion object {
+        private const val REQUEST_CREDIT_CARD = 100
+    }
 }
 
 interface PaymentCreatorNavigation {
@@ -44,7 +68,11 @@ interface PaymentCreatorNavigation {
     fun navigateToEContextForm()
 }
 
-open class PaymentCreatorNavigationImpl(activity: PaymentCreatorActivity) : PaymentCreatorNavigation {
+private class PaymentCreatorNavigationImpl(
+        private val activity: PaymentCreatorActivity,
+        private val pkey: String,
+        private val requestCode: Int
+) : PaymentCreatorNavigation {
     companion object {
         const val FRAGMENT_STACK = "PaymentCreatorNavigation.fragmentStack"
     }
@@ -66,7 +94,10 @@ open class PaymentCreatorNavigationImpl(activity: PaymentCreatorActivity) : Paym
     }
 
     override fun navigateToCreditCardForm() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        val intent = Intent(activity, CreditCardActivity::class.java).apply {
+            putExtra(EXTRA_PKEY, pkey)
+        }
+        activity.startActivityForResult(intent, requestCode)
     }
 
     override fun navigateToInternetBankingChooser() {

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -23,7 +23,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
-import co.omise.android.ui.CreditCardActivity.Companion.EXTRA_PKEY
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
@@ -37,7 +36,7 @@ class CreditCardActivityTest {
 
     private lateinit var scenario: ActivityScenario<CreditCardActivity>
     private val intent = Intent(getApplicationContext(), CreditCardActivity::class.java).apply {
-        putExtra(EXTRA_PKEY, "test_key1234")
+        putExtra(OmiseActivity.EXTRA_PKEY, "test_key1234")
     }
 
     @Before

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -36,7 +36,7 @@ class PaymentChooserFragmentTest {
     private val mockNavigation = mock(PaymentCreatorNavigation::class.java)
 
     @get:Rule
-    val mActivityRule = IntentsTestRule<TestFragmentActivity>(TestFragmentActivity::class.java)
+    val intentRule = IntentsTestRule<TestFragmentActivity>(TestFragmentActivity::class.java)
 
     @Before
     fun setUp() {

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -1,20 +1,32 @@
 package co.omise.android.ui
 
+import android.app.Activity.RESULT_OK
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
 import co.omise.android.models.Capability
+import co.omise.android.models.Token
+import co.omise.android.ui.OmiseActivity.Companion.EXTRA_TOKEN
+import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PaymentCreatorActivityTest {
+
+    @get:Rule
+    val intentRule = IntentsTestRule<TestFragmentActivity>(TestFragmentActivity::class.java)
 
     private lateinit var scenario: ActivityScenario<PaymentCreatorActivity>
     private val capability = Capability()
@@ -41,5 +53,29 @@ class PaymentCreatorActivityTest {
                 PaymentCreatorActivity::class.java
         )
         scenario = ActivityScenario.launch(noExtrasIntent)
+    }
+
+    @Test
+    fun navigateToCreditCardForm_startCreditCartActivity() {
+        var activity: PaymentCreatorActivity? = null
+        scenario = ActivityScenario.launch<PaymentCreatorActivity>(intent).onActivity {
+            activity = it
+        }
+
+        activity?.navigation?.navigateToCreditCardForm()
+
+        intended(hasComponent(hasClassName(CreditCardActivity::class.java.name)))
+    }
+
+    @Test
+    fun creditCardResult_resultOk() {
+        val creditCardIntent = Intent().apply {
+            putExtra(EXTRA_TOKEN, Token())
+        }
+        scenario = ActivityScenario.launch<PaymentCreatorActivity>(intent).onActivity {
+            it.performActivityResult(100, RESULT_OK, creditCardIntent)
+        }
+
+        assertEquals(RESULT_OK, scenario.result.resultCode)
     }
 }


### PR DESCRIPTION
### Objective 

Continue implementing the payment creator by this PR implement creating a payment from the existed credit card form.

### Description of changes

From the payment chooser, when the user pressed the credit card method, it will navigate to `CreditCardActivity`  and return a token result when creating token success.

### QA

On the sample app, when creating a payment from the credit card form will get a Token as a response.

![Sep-10-2562 11-11-17](https://user-images.githubusercontent.com/2638321/64583629-df499f80-d3bb-11e9-912d-d1cc453c5de3.gif)

