### PR TITLE
Create payment from installment

### DIFF
--- a/sdk/src/main/java/co/omise/android/models/SourceType.kt
+++ b/sdk/src/main/java/co/omise/android/models/SourceType.kt
@@ -36,6 +36,18 @@ sealed class SourceType(
         object Ktc : Installment("installment_ktc")
         object KBank : Installment("installment_kbank")
         data class Unknown(@JsonValue override val name: String?) : Installment(name)
+
+        companion object {
+            fun availableTerms(installment: Installment): List<Int> =
+                    when (installment) {
+                        Bay -> listOf(3, 4, 6, 9, 10)
+                        FirstChoice -> listOf(3, 4, 6, 9, 10, 12, 18, 24, 36)
+                        Bbl -> listOf(4, 6, 8, 9, 10)
+                        Ktc -> listOf(3, 4, 5, 6, 7, 8, 9, 10)
+                        KBank -> listOf(3, 4, 6, 10)
+                        is Unknown -> emptyList()
+                    }
+        }
     }
 
     companion object {

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
@@ -10,11 +10,12 @@ import co.omise.android.models.backendType
 
 internal class InstallmentChooserFragment : OmiseListFragment<InstallmentChooserItem>() {
 
+    private val paymentMethods: List<PaymentMethod> by lazy {
+        val args = arguments ?: return@lazy emptyList<PaymentMethod>()
+        return@lazy (args.getParcelableArray(EXTRA_INSTALLMENT_METHODS) as Array<PaymentMethod>).toList()
+    }
     private val allowedInstallments: List<SourceType.Installment> by lazy {
-        val args = arguments ?: return@lazy emptyList<SourceType.Installment>()
-        val paymentMethods = args.getParcelableArray(EXTRA_INSTALLMENT_METHODS) as Array<PaymentMethod>
-        return@lazy paymentMethods
-                .filter { it.backendType is BackendType.Source && (it.backendType as BackendType.Source).sourceType is SourceType.Installment }
+        return@lazy paymentMethods.filter { it.backendType is BackendType.Source && (it.backendType as BackendType.Source).sourceType is SourceType.Installment }
                 .map { (it.backendType as BackendType.Source).sourceType as SourceType.Installment }
     }
     var navigation: PaymentCreatorNavigation? = null
@@ -48,7 +49,8 @@ internal class InstallmentChooserFragment : OmiseListFragment<InstallmentChooser
             InstallmentChooserItem.Ktc -> SourceType.Installment.Ktc
             is InstallmentChooserItem.Unknown -> SourceType.Installment.Unknown(item.bankName)
         }
-//        paymentCreatorActivity.showInstallmentTermChooser(installment)
+        val choseInstallment = paymentMethods.first { (it.backendType as BackendType.Source).sourceType == sourceType }
+        navigation?.navigateToInstallmentTermChooser(choseInstallment)
     }
 
     companion object {
@@ -71,8 +73,8 @@ internal sealed class InstallmentChooserItem(
     companion object
     object Bbl : InstallmentChooserItem(R.drawable.payment_bbl, "Bangkok Bank", R.drawable.ic_next)
     object KBank : InstallmentChooserItem(R.drawable.payment_kasikorn, "Kasikorn", R.drawable.ic_next)
-    object Bay : InstallmentChooserItem(R.drawable.payment_bay, "krungsri", R.drawable.ic_next)
-    object FirstChoice : InstallmentChooserItem(R.drawable.payment_first_choice, "krungsri First FirstChoice", R.drawable.ic_next)
+    object Bay : InstallmentChooserItem(R.drawable.payment_bay, "Krungsri", R.drawable.ic_next)
+    object FirstChoice : InstallmentChooserItem(R.drawable.payment_first_choice, "Krungsri First Choice", R.drawable.ic_next)
     object Ktc : InstallmentChooserItem(R.drawable.payment_ktc, "KTC", R.drawable.ic_next)
     data class Unknown(val bankName: String) : InstallmentChooserItem(R.drawable.payment_installment, bankName, R.drawable.ic_next)
 }

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
@@ -23,6 +23,7 @@ internal class InstallmentChooserFragment : OmiseListFragment<InstallmentChooser
         super.onActivityCreated(savedInstanceState)
 
         title = getString(R.string.installments_title)
+        setHasOptionsMenu(true)
     }
 
     override fun listItems(): List<InstallmentChooserItem> {

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
@@ -1,0 +1,77 @@
+package co.omise.android.ui
+
+
+import android.os.Bundle
+import co.omise.android.R
+import co.omise.android.models.BackendType
+import co.omise.android.models.PaymentMethod
+import co.omise.android.models.SourceType
+import co.omise.android.models.backendType
+
+internal class InstallmentChooserFragment : OmiseListFragment<InstallmentChooserItem>() {
+
+    private val allowedInstallments: List<SourceType.Installment> by lazy {
+        val args = arguments ?: return@lazy emptyList<SourceType.Installment>()
+        val paymentMethods = args.getParcelableArray(EXTRA_INSTALLMENT_METHODS) as Array<PaymentMethod>
+        return@lazy paymentMethods
+                .filter { it.backendType is BackendType.Source && (it.backendType as BackendType.Source).sourceType is SourceType.Installment }
+                .map { (it.backendType as BackendType.Source).sourceType as SourceType.Installment }
+    }
+    var navigation: PaymentCreatorNavigation? = null
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        title = getString(R.string.installments_title)
+    }
+
+    override fun listItems(): List<InstallmentChooserItem> {
+        return allowedInstallments.map {
+            when (it) {
+                SourceType.Installment.KBank -> InstallmentChooserItem.KBank
+                SourceType.Installment.Bay -> InstallmentChooserItem.Bay
+                SourceType.Installment.FirstChoice -> InstallmentChooserItem.FirstChoice
+                SourceType.Installment.Bbl -> InstallmentChooserItem.Bbl
+                SourceType.Installment.Ktc -> InstallmentChooserItem.Ktc
+                is SourceType.Installment.Unknown -> InstallmentChooserItem.Unknown(it.name.orEmpty())
+            }
+        }
+    }
+
+    override fun onListItemClicked(item: InstallmentChooserItem) {
+        val sourceType = when (item) {
+            InstallmentChooserItem.Bbl -> SourceType.Installment.Bbl
+            InstallmentChooserItem.KBank -> SourceType.Installment.KBank
+            InstallmentChooserItem.Bay -> SourceType.Installment.Bay
+            InstallmentChooserItem.FirstChoice -> SourceType.Installment.FirstChoice
+            InstallmentChooserItem.Ktc -> SourceType.Installment.Ktc
+            is InstallmentChooserItem.Unknown -> SourceType.Installment.Unknown(item.bankName)
+        }
+//        paymentCreatorActivity.showInstallmentTermChooser(installment)
+    }
+
+    companion object {
+        private const val EXTRA_INSTALLMENT_METHODS = "InstallmentChooserFragment.installmentMethods"
+
+        fun newInstance(availableBanks: List<PaymentMethod>) =
+                InstallmentChooserFragment().apply {
+                    arguments = Bundle().apply {
+                        putParcelableArray(EXTRA_INSTALLMENT_METHODS, availableBanks.toTypedArray())
+                    }
+                }
+    }
+}
+
+internal sealed class InstallmentChooserItem(
+        override val icon: Int,
+        override val title: String,
+        override val indicatorIcon: Int
+) : OmiseListItem {
+    companion object
+    object Bbl : InstallmentChooserItem(R.drawable.payment_bbl, "Bangkok Bank", R.drawable.ic_next)
+    object KBank : InstallmentChooserItem(R.drawable.payment_kasikorn, "Kasikorn", R.drawable.ic_next)
+    object Bay : InstallmentChooserItem(R.drawable.payment_bay, "krungsri", R.drawable.ic_next)
+    object FirstChoice : InstallmentChooserItem(R.drawable.payment_first_choice, "krungsri First FirstChoice", R.drawable.ic_next)
+    object Ktc : InstallmentChooserItem(R.drawable.payment_ktc, "KTC", R.drawable.ic_next)
+    data class Unknown(val bankName: String) : InstallmentChooserItem(R.drawable.payment_installment, bankName, R.drawable.ic_next)
+}

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -5,6 +5,7 @@ import co.omise.android.R
 import co.omise.android.models.BackendType
 import co.omise.android.models.PaymentMethod
 import co.omise.android.models.Source
+import co.omise.android.models.SourceType
 import co.omise.android.models.backendType
 
 
@@ -16,7 +17,16 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        title = (installment?.backendType as? BackendType.Source)?.sourceType?.name.orEmpty()
+
+        val sourceType = (installment?.backendType as BackendType.Source).sourceType
+        title = when (sourceType as SourceType.Installment) {
+            SourceType.Installment.Bay -> InstallmentChooserItem.Bay
+            SourceType.Installment.FirstChoice -> InstallmentChooserItem.FirstChoice
+            SourceType.Installment.Bbl -> InstallmentChooserItem.Bbl
+            SourceType.Installment.Ktc -> InstallmentChooserItem.Ktc
+            SourceType.Installment.KBank -> InstallmentChooserItem.KBank
+            is SourceType.Installment.Unknown -> InstallmentChooserItem.Unknown(sourceType.name.orEmpty())
+        }.title
         setHasOptionsMenu(true)
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -1,0 +1,54 @@
+package co.omise.android.ui
+
+import android.os.Bundle
+import co.omise.android.R
+import co.omise.android.models.BackendType
+import co.omise.android.models.PaymentMethod
+import co.omise.android.models.Source
+import co.omise.android.models.backendType
+
+
+internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTermChooserItem>() {
+    var requester: PaymentCreatorRequester<Source>? = null
+    private val installment: PaymentMethod? by lazy {
+        arguments?.getParcelable<PaymentMethod>(EXTRA_INSTALLMENT)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        title = (installment?.backendType as BackendType.Source).sourceType.name.orEmpty()
+        setHasOptionsMenu(true)
+    }
+
+    override fun listItems(): List<InstallmentTermChooserItem> {
+        return installment?.installmentTerms.orEmpty().map {
+            InstallmentTermChooserItem(
+                    R.drawable.payment_installment,
+                    "$it months",
+                    R.drawable.ic_redirect
+            )
+        }
+    }
+
+    override fun onListItemClicked(option: InstallmentTermChooserItem) {
+//        val sourceType = installment?.sourceType ?: return
+//        paymentCreatorFlow?.request(PaymentCreatorParameter.Installment(sourceType, option.terms))
+    }
+
+    companion object {
+        private const val EXTRA_INSTALLMENT = "InstallmentTermChooserFragment.installment"
+        fun newInstance(installment: PaymentMethod) =
+                InstallmentTermChooserFragment().apply {
+                    val args = Bundle().apply {
+                        putParcelable(EXTRA_INSTALLMENT, installment)
+                    }
+                    arguments = args
+                }
+    }
+}
+
+internal data class InstallmentTermChooserItem(
+        override val icon: Int,
+        override val title: String,
+        override val indicatorIcon: Int
+) : OmiseListItem

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -22,17 +22,21 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
 
     override fun listItems(): List<InstallmentTermChooserItem> {
         return installment?.installmentTerms.orEmpty().map {
-            InstallmentTermChooserItem(
-                    R.drawable.payment_installment,
-                    "$it months",
-                    R.drawable.ic_redirect
-            )
+            InstallmentTermChooserItem(R.drawable.payment_installment, it, R.drawable.ic_redirect)
         }
     }
 
-    override fun onListItemClicked(option: InstallmentTermChooserItem) {
-//        val sourceType = installment?.sourceType ?: return
-//        paymentCreatorFlow?.request(PaymentCreatorParameter.Installment(sourceType, option.terms))
+    override fun onListItemClicked(item: InstallmentTermChooserItem) {
+        val req = requester ?: return
+        val sourceType = (installment?.backendType as? BackendType.Source)?.sourceType ?: return
+
+        setUiEnabled(false)
+        val request = Source.CreateSourceRequestBuilder(req.amount, req.currency, sourceType)
+                .installmentTerm(item.installmentTerm)
+                .build()
+        requester?.request(request) {
+            setUiEnabled(true)
+        }
     }
 
     companion object {
@@ -49,6 +53,9 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
 
 internal data class InstallmentTermChooserItem(
         override val icon: Int,
-        override val title: String,
+        val installmentTerm: Int,
         override val indicatorIcon: Int
-) : OmiseListItem
+) : OmiseListItem {
+    override val title: String
+        get() = "$installmentTerm months"
+}

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -16,7 +16,7 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        title = (installment?.backendType as BackendType.Source).sourceType.name.orEmpty()
+        title = (installment?.backendType as? BackendType.Source)?.sourceType?.name.orEmpty()
         setHasOptionsMenu(true)
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/InternetBankingChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InternetBankingChooserFragment.kt
@@ -54,7 +54,7 @@ internal class InternetBankingChooserFragment : OmiseListFragment<InternetBankin
                 SourceType.InternetBanking.Scb -> InternetBankingChooserItem.Scb
                 SourceType.InternetBanking.Bay -> InternetBankingChooserItem.Bay
                 SourceType.InternetBanking.Ktb -> InternetBankingChooserItem.Ktb
-                else -> InternetBankingChooserItem.Unknown(it.name.orEmpty())
+                is SourceType.InternetBanking.Unknown -> InternetBankingChooserItem.Unknown(it.name.orEmpty())
             }
         }
     }

--- a/sdk/src/main/java/co/omise/android/ui/OmiseFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseFragment.kt
@@ -1,17 +1,28 @@
 package co.omise.android.ui
 
+import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import kotlin.properties.Delegates
 
 
 abstract class OmiseFragment : Fragment() {
-    var title: String by Delegates.observable("", { _, _, newValue ->
-        (activity as? AppCompatActivity)?.supportActionBar?.title = newValue
-    })
+
+    var title: String? = null
+
+    protected val actionBar: ActionBar?
+        get() = (activity as? AppCompatActivity)?.supportActionBar
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        fragmentManager?.addOnBackStackChangedListener {
+            actionBar?.title = title
+        }
+    }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -23,7 +23,12 @@ class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
     override fun onListItemClicked(item: PaymentChooserItem) {
         when (item) {
             PaymentChooserItem.CreditCard -> navigation?.navigateToCreditCardForm()
-            PaymentChooserItem.Installments -> TODO()
+            PaymentChooserItem.Installments -> navigation?.navigateToInstallmentChooser(
+                    capability
+                            ?.paymentMethods
+                            ?.filter { it.backendType is BackendType.Source && (it.backendType as BackendType.Source).sourceType is SourceType.Installment }
+                            .orEmpty()
+            )
             PaymentChooserItem.InternetBanking -> navigation?.navigateToInternetBankingChooser(
                     capability
                             ?.paymentMethods

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -103,6 +103,7 @@ interface PaymentCreatorNavigation {
     fun navigateToCreditCardForm()
     fun navigateToInternetBankingChooser(allowedBanks: List<PaymentMethod>)
     fun navigateToInstallmentChooser(allowedInstalls: List<PaymentMethod>)
+    fun navigateToInstallmentTermChooser(installment: PaymentMethod)
     fun navigateToEContextForm()
     fun createSourceFinished(source: Source)
 }
@@ -151,6 +152,13 @@ private class PaymentCreatorNavigationImpl(
     override fun navigateToInstallmentChooser(allowedInstalls: List<PaymentMethod>) {
         val fragment = InstallmentChooserFragment.newInstance(allowedInstalls).apply {
             navigation = this@PaymentCreatorNavigationImpl
+        }
+        addFragmentToBackStack(fragment)
+    }
+
+    override fun navigateToInstallmentTermChooser(installment: PaymentMethod) {
+        val fragment = InstallmentTermChooserFragment.newInstance(installment).apply {
+            requester = this@PaymentCreatorNavigationImpl.requester
         }
         addFragmentToBackStack(fragment)
     }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -101,8 +101,8 @@ class PaymentCreatorActivity : OmiseActivity() {
 interface PaymentCreatorNavigation {
     fun navigateToPaymentChooser(capability: Capability)
     fun navigateToCreditCardForm()
-    fun navigateToInternetBankingChooser(availableBanks: List<PaymentMethod>)
-    fun navigateToInstallmentChooser()
+    fun navigateToInternetBankingChooser(allowedBanks: List<PaymentMethod>)
+    fun navigateToInstallmentChooser(allowedInstalls: List<PaymentMethod>)
     fun navigateToEContextForm()
     fun createSourceFinished(source: Source)
 }
@@ -141,15 +141,18 @@ private class PaymentCreatorNavigationImpl(
         activity.startActivityForResult(intent, requestCode)
     }
 
-    override fun navigateToInternetBankingChooser(availableBanks: List<PaymentMethod>) {
-        val fragment = InternetBankingChooserFragment.newInstance(availableBanks).apply {
+    override fun navigateToInternetBankingChooser(allowedBanks: List<PaymentMethod>) {
+        val fragment = InternetBankingChooserFragment.newInstance(allowedBanks).apply {
             requester = this@PaymentCreatorNavigationImpl.requester
         }
         addFragmentToBackStack(fragment)
     }
 
-    override fun navigateToInstallmentChooser() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    override fun navigateToInstallmentChooser(allowedInstalls: List<PaymentMethod>) {
+        val fragment = InstallmentChooserFragment.newInstance(allowedInstalls).apply {
+            navigation = this@PaymentCreatorNavigationImpl
+        }
+        addFragmentToBackStack(fragment)
     }
 
     override fun navigateToEContextForm() {

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -32,5 +32,6 @@
     <string name="cvv_tooltip_4_digits">4 digit number on the\nfront of your card</string>
     <string name="payment_chooser_title">Payment Methods</string>
     <string name="internet_banking_chooser_title">Internet Banking</string>
+    <string name="installments_title">Installments</string>
     <string name="menu_title_close">Close</string>
 </resources>

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
@@ -1,0 +1,45 @@
+package co.omise.android.ui
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import co.omise.android.R
+import co.omise.android.models.PaymentMethod
+import co.omise.android.utils.itemCount
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class InstallmentChooserFragmentTest {
+
+    private val paymentMethods = listOf(
+            PaymentMethod(name = "installment_bay"),
+            PaymentMethod(name = "installment_bbl"),
+            PaymentMethod(name = "installment_first_choice"),
+            PaymentMethod(name = "installment_kbank"),
+            PaymentMethod(name = "installment_ktc")
+    )
+    private val mockNavigation: PaymentCreatorNavigation = mock()
+    private val fragment = InstallmentChooserFragment.newInstance(paymentMethods).apply {
+        navigation = mockNavigation
+    }
+
+    @Before
+    fun setUp() {
+        ActivityScenario.launch(TestFragmentActivity::class.java).onActivity {
+            it.replaceFragment(fragment)
+        }
+
+        onView(ViewMatchers.withText(R.string.installments_title))
+                .check(matches(ViewMatchers.isDisplayed()))
+    }
+
+    @Test
+    fun displayAllowedInstallmentBanks_showAllowedInstallmentBanksFromArgument() {
+        onView(ViewMatchers.withId(R.id.recycler_view)).check(matches(itemCount(paymentMethods.size)))
+    }
+}

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
 import co.omise.android.models.PaymentMethod
@@ -34,12 +35,11 @@ class InstallmentChooserFragmentTest {
             it.replaceFragment(fragment)
         }
 
-        onView(ViewMatchers.withText(R.string.installments_title))
-                .check(matches(ViewMatchers.isDisplayed()))
+        onView(withText(R.string.installments_title)).check(matches(isDisplayed()))
     }
 
     @Test
     fun displayAllowedInstallmentBanks_showAllowedInstallmentBanksFromArgument() {
-        onView(ViewMatchers.withId(R.id.recycler_view)).check(matches(itemCount(paymentMethods.size)))
+        onView(withId(R.id.recycler_view)).check(matches(itemCount(paymentMethods.size)))
     }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentTermChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentTermChooserFragmentTest.kt
@@ -44,7 +44,7 @@ class InstallmentTermChooserFragmentTest {
             it.replaceFragment(fragment)
         }
 
-        onView(withText(paymentMethod.name)).check(matches(isDisplayed()))
+        onView(withText(InstallmentChooserItem.Bay.title)).check(matches(isDisplayed()))
     }
 
     @Test

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentTermChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentTermChooserFragmentTest.kt
@@ -1,0 +1,63 @@
+package co.omise.android.ui
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import co.omise.android.R
+import co.omise.android.models.PaymentMethod
+import co.omise.android.models.Source
+import co.omise.android.utils.itemCount
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.hamcrest.CoreMatchers.not
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class InstallmentTermChooserFragmentTest {
+
+    private val paymentMethod = PaymentMethod(
+            name = "installment_bay",
+            installmentTerms = listOf(3, 4, 6, 9, 10))
+    private val mockRequester: PaymentCreatorRequester<Source> = mock {
+        on { amount }.doReturn(500000L)
+        on { currency }.doReturn("thb")
+    }
+
+    private val fragment = InstallmentTermChooserFragment.newInstance(paymentMethod).apply {
+        requester = mockRequester
+    }
+
+    @Before
+    fun setUp() {
+        ActivityScenario.launch(TestFragmentActivity::class.java).onActivity {
+            it.replaceFragment(fragment)
+        }
+
+        onView(withText(paymentMethod.name)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun displayAllowedInstallmentTerms_showAllowedInstallmentTermsFromArgument() {
+        onView(withId(R.id.recycler_view)).check(matches(itemCount(paymentMethod.installmentTerms!!.size)))
+    }
+
+    @Test
+    fun clickInstallmentTerm_sendRequestToCreateSource() {
+        onView(withId(R.id.recycler_view))
+                .perform(actionOnItemAtPosition<OmiseItemViewHolder>(0, click()))
+
+        onView(withId(R.id.recycler_view)).check(matches(not(isEnabled())))
+        verify(mockRequester).request(any(), any())
+    }
+}

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -108,4 +108,19 @@ class PaymentChooserFragmentTest {
         )
         verify(fragment.navigation)?.navigateToInternetBankingChooser(expectedMethods)
     }
+
+    @Test
+    fun clickInstallmentPaymentMethod_navigateToInstallmentChooser() {
+        onView(withId(R.id.recycler_view))
+                .perform(actionOnItemAtPosition<OmiseItemViewHolder>(1, click()))
+
+        val expectedMethods = listOf(
+                PaymentMethod(name = "installment_bay"),
+                PaymentMethod(name = "installment_bbl"),
+                PaymentMethod(name = "installment_first_choice"),
+                PaymentMethod(name = "installment_kbank"),
+                PaymentMethod(name = "installment_ktc")
+        )
+        verify(fragment.navigation)?.navigateToInstallmentChooser(expectedMethods)
+    }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -45,7 +45,7 @@ class PaymentChooserFragmentTest {
                 PaymentMethod(name = "installment_bay"),
                 PaymentMethod(name = "installment_bbl"),
                 PaymentMethod(name = "installment_first_choice"),
-                PaymentMethod(name = "installment_kabnk"),
+                PaymentMethod(name = "installment_kbank"),
                 PaymentMethod(name = "installment_ktc"),
                 PaymentMethod(name = "internet_banking_bay"),
                 PaymentMethod(name = "internet_banking_bbl"),

--- a/sdk/src/sharedTest/java/co/omise/android/ui/TestFragmentActivity.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/TestFragmentActivity.kt
@@ -34,7 +34,8 @@ class TestFragmentActivity : AppCompatActivity() {
 
     fun replaceFragment(fragment: Fragment) {
         supportFragmentManager.beginTransaction()
-                .replace(android.R.id.content, fragment)
+                .add(android.R.id.content, fragment)
+                .addToBackStack("test_fragment")
                 .commit()
     }
 }


### PR DESCRIPTION
### Objective

Create the installment chooser page to able users to create a payment from the installment method.

### Description of changes

In this PR create new 2 pages for the flow. The first page is `InstallmentChooserFragment` for choosing a bank issuer. 

And the second page is `InstallmentTermChooserFragment` for choosing an installment term. After the user chose an installment term, it will send a request to create a source object.

### QA

To test creating a source from the installment method, you can open the sample app and choose the installment method. Then choose a bank issuer and installment term it should return source object.

![Screenshot_1568361166](https://user-images.githubusercontent.com/2638321/64846202-35297c00-d636-11e9-9077-c6a2242287bc.png)

![Screenshot_1568361171](https://user-images.githubusercontent.com/2638321/64846209-39ee3000-d636-11e9-9b6f-73c45feac88b.png)

