### PR TITLE
Create payment from EContext

### DIFF
--- a/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
+++ b/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
@@ -11,7 +11,7 @@ data class PaymentMethod(
         @field:JsonProperty("card_brands")
         var cardBrands: List<String>? = null,
         @field:JsonProperty("installment_terms")
-        val installmentTerms: List<Int>? = null,
+        var installmentTerms: List<Int>? = null,
         override var modelObject: String? = null,
         override var id: String? = null,
         override var livemode: Boolean = false,

--- a/sdk/src/main/java/co/omise/android/models/SourceType.kt
+++ b/sdk/src/main/java/co/omise/android/models/SourceType.kt
@@ -2,9 +2,11 @@ package co.omise.android.models
 
 import android.annotation.SuppressLint
 import android.os.Parcel
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import kotlinx.android.parcel.Parceler
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Represents Source Type object.
@@ -101,3 +103,14 @@ val SourceType.Companion.allElements: List<SourceType>
             SourceType.Installment.Ktc,
             SourceType.Installment.KBank
     )
+
+sealed class SupportedEContext : Parcelable {
+    @Parcelize
+    object ConvenienceStore : SupportedEContext()
+
+    @Parcelize
+    object PayEasy : SupportedEContext()
+
+    @Parcelize
+    object Netbanking : SupportedEContext()
+}

--- a/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
@@ -11,6 +11,7 @@ import android.widget.TextView
 import co.omise.android.R
 import co.omise.android.extensions.setOnAfterTextChangeListener
 import co.omise.android.extensions.setOnClickListener
+import co.omise.android.models.SupportedEContext
 import co.omise.android.models.Source
 import co.omise.android.models.SourceType
 import kotlinx.android.synthetic.main.fragment_econtext_form.button_submit
@@ -26,6 +27,9 @@ class EContextFormFragment : OmiseFragment() {
 
     var requester: PaymentCreatorRequester<Source>? = null
 
+    private val type: SupportedEContext? by lazy {
+        arguments?.getParcelable<SupportedEContext>(EXTRA_ECONTEXT_TYPE)
+    }
     private val fullNameEdit: OmiseEditText by lazy { edit_full_name }
     private val emailEdit: OmiseEditText by lazy { edit_email }
     private val phoneNumberEdit: OmiseEditText by lazy { edit_phone_number }
@@ -48,7 +52,12 @@ class EContextFormFragment : OmiseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        title = getString(R.string.econtext_title)
+        title = when (type) {
+            SupportedEContext.ConvenienceStore -> getString(R.string.title_convenience_store)
+            SupportedEContext.PayEasy -> getString(R.string.title_pay_easy)
+            SupportedEContext.Netbanking -> getString(R.string.title_netbanking)
+            null -> getString(R.string.econtext_title)
+        }
         setHasOptionsMenu(true)
 
         formInputWithErrorTexts.forEach {
@@ -107,6 +116,11 @@ class EContextFormFragment : OmiseFragment() {
     }
 
     companion object {
-        fun newInstance(): EContextFormFragment = EContextFormFragment()
+        private const val EXTRA_ECONTEXT_TYPE = "EContextFormFragment.econtextType"
+        fun newInstance(eContext: SupportedEContext): EContextFormFragment = EContextFormFragment().apply {
+            arguments = Bundle().apply {
+                putParcelable(EXTRA_ECONTEXT_TYPE, eContext)
+            }
+        }
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
@@ -86,9 +86,9 @@ class EContextFormFragment : OmiseFragment() {
         submitButton.isEnabled = isFormValid
     }
 
-
     private fun submitForm() {
         val requester = requester ?: return
+
 
         val fullName = fullNameEdit.text?.toString()?.trim().orEmpty()
         val email = emailEdit.text?.toString()?.trim().orEmpty()
@@ -100,8 +100,9 @@ class EContextFormFragment : OmiseFragment() {
                 .phoneNumber(phoneNumber)
                 .build()
 
+        view?.let { setAllViewsEnabled(it, false) }
         requester.request(request) {
-
+            view?.let { setAllViewsEnabled(it, true) }
         }
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
@@ -3,6 +3,8 @@ package co.omise.android.ui
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
@@ -58,7 +60,24 @@ class EContextFormFragment : OmiseFragment() {
     }
 
     private fun updateErrorText(view: View, hasFocus: Boolean) {
+        val editText = view as OmiseEditText
+        val errorText = formInputWithErrorTexts.first { it.first == editText }.second
 
+        if (hasFocus || editText.isValid) {
+            errorText.text = ""
+            errorText.visibility = INVISIBLE
+            return
+        }
+
+        val errorMessage = when (editText) {
+            fullNameEdit -> R.string.error_invalid_full_name
+            emailEdit -> R.string.error_invalid_email
+            phoneNumberEdit -> R.string.error_invalid_phone_number
+            else -> R.string.error_invalid_unknown
+        }
+
+        errorText.text = getString(errorMessage)
+        errorText.visibility = VISIBLE
     }
 
     private fun updateSubmitButton() {

--- a/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
@@ -98,7 +98,6 @@ class EContextFormFragment : OmiseFragment() {
     private fun submitForm() {
         val requester = requester ?: return
 
-
         val fullName = fullNameEdit.text?.toString()?.trim().orEmpty()
         val email = emailEdit.text?.toString()?.trim().orEmpty()
         val phoneNumber = phoneNumberEdit.text?.toString()?.trim().orEmpty()

--- a/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/EContextFormFragment.kt
@@ -1,0 +1,51 @@
+package co.omise.android.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import co.omise.android.R
+import co.omise.android.extensions.setOnClickListener
+import co.omise.android.models.Source
+import kotlinx.android.synthetic.main.fragment_econtext_form.button_submit
+import kotlinx.android.synthetic.main.fragment_econtext_form.edit_email
+import kotlinx.android.synthetic.main.fragment_econtext_form.edit_full_name
+import kotlinx.android.synthetic.main.fragment_econtext_form.edit_phone
+
+
+class EContextFormFragment : OmiseFragment() {
+
+    var requester: PaymentCreatorRequester<Source>? = null
+
+    private val fullNameEdit: OmiseEditText by lazy { edit_full_name }
+    private val emailEdit: OmiseEditText by lazy { edit_email }
+    private val phoneEdit: OmiseEditText by lazy { edit_phone }
+    private val submitButton: Button by lazy { button_submit }
+    private val formEdits: List<OmiseEditText> by lazy {
+        listOf(fullNameEdit, emailEdit, phoneEdit)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_econtext_form, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        title = getString(R.string.econtext_title)
+        setHasOptionsMenu(true)
+
+        submitButton.setOnClickListener(::submitForm)
+    }
+
+    private fun submitForm() {
+        val fullName = fullNameEdit.text?.toString()?.trim() ?: ""
+        val email = emailEdit.text?.toString()?.trim() ?: ""
+        val phone = phoneEdit.text?.toString()?.trim() ?: ""
+    }
+
+    companion object {
+        fun newInstance(): EContextFormFragment = EContextFormFragment()
+    }
+}

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -40,12 +40,12 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
         val req = requester ?: return
         val sourceType = (installment?.backendType as? BackendType.Source)?.sourceType ?: return
 
-        setUiEnabled(false)
+        view?.let { setAllViewsEnabled(it, false) }
         val request = Source.CreateSourceRequestBuilder(req.amount, req.currency, sourceType)
                 .installmentTerm(item.installmentTerm)
                 .build()
         requester?.request(request) {
-            setUiEnabled(true)
+            view?.let { setAllViewsEnabled(it, true) }
         }
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/InternetBankingChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InternetBankingChooserFragment.kt
@@ -31,7 +31,7 @@ internal class InternetBankingChooserFragment : OmiseListFragment<InternetBankin
     override fun onListItemClicked(item: InternetBankingChooserItem) {
         val req = requester ?: return
 
-        setUiEnabled(false)
+        view?.let { setAllViewsEnabled(it, false) }
 
         val sourceType = when (item) {
             InternetBankingChooserItem.Bbl -> SourceType.InternetBanking.Bbl
@@ -43,7 +43,7 @@ internal class InternetBankingChooserFragment : OmiseListFragment<InternetBankin
 
         val request = Source.CreateSourceRequestBuilder(req.amount, req.currency, sourceType).build()
         requester?.request(request) {
-            setUiEnabled(true)
+            view?.let { setAllViewsEnabled(it, true) }
         }
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/OmiseFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -36,5 +38,18 @@ abstract class OmiseFragment : Fragment() {
             }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    protected fun setAllViewsEnabled(view: View, isEnabled: Boolean) {
+        view.isEnabled = isEnabled
+        if (view is ViewGroup) {
+            for (index in 0 until view.childCount) {
+                val targetView = view.getChildAt(index)
+                targetView.isEnabled = isEnabled
+                if (targetView is ViewGroup) {
+                    setAllViewsEnabled(targetView, isEnabled)
+                }
+            }
+        }
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import co.omise.android.R
 import co.omise.android.models.BackendType
 import co.omise.android.models.Capability
+import co.omise.android.models.SupportedEContext
 import co.omise.android.models.SourceType
 import co.omise.android.models.backendType
 
@@ -36,9 +37,9 @@ class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
                             .orEmpty()
             )
             PaymentChooserItem.TescoLotus -> TODO()
-            PaymentChooserItem.ConvenienceStore -> navigation?.navigateToEContextForm()
-            PaymentChooserItem.PayEasy -> navigation?.navigateToEContextForm()
-            PaymentChooserItem.Netbanking -> navigation?.navigateToEContextForm()
+            PaymentChooserItem.ConvenienceStore -> navigation?.navigateToEContextForm(SupportedEContext.ConvenienceStore)
+            PaymentChooserItem.PayEasy -> navigation?.navigateToEContextForm(SupportedEContext.PayEasy)
+            PaymentChooserItem.Netbanking -> navigation?.navigateToEContextForm(SupportedEContext.Netbanking)
             PaymentChooserItem.Alipay -> TODO()
         }
     }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -36,9 +36,9 @@ class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
                             .orEmpty()
             )
             PaymentChooserItem.TescoLotus -> TODO()
-            PaymentChooserItem.ConvenienceStore -> TODO()
-            PaymentChooserItem.PayEasy -> TODO()
-            PaymentChooserItem.Netbanking -> TODO()
+            PaymentChooserItem.ConvenienceStore -> navigation?.navigateToEContextForm()
+            PaymentChooserItem.PayEasy -> navigation?.navigateToEContextForm()
+            PaymentChooserItem.Netbanking -> navigation?.navigateToEContextForm()
             PaymentChooserItem.Alipay -> TODO()
         }
     }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -164,7 +164,9 @@ private class PaymentCreatorNavigationImpl(
     }
 
     override fun navigateToEContextForm() {
-        val fragment = EContextFormFragment.newInstance()
+        val fragment = EContextFormFragment.newInstance().apply {
+            requester = this@PaymentCreatorNavigationImpl.requester
+        }
         addFragmentToBackStack(fragment)
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -164,7 +164,8 @@ private class PaymentCreatorNavigationImpl(
     }
 
     override fun navigateToEContextForm() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        val fragment = EContextFormFragment.newInstance()
+        addFragmentToBackStack(fragment)
     }
 
     override fun createSourceFinished(source: Source) {

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -10,6 +10,7 @@ import co.omise.android.api.Client
 import co.omise.android.api.Request
 import co.omise.android.api.RequestListener
 import co.omise.android.models.Capability
+import co.omise.android.models.SupportedEContext
 import co.omise.android.models.Model
 import co.omise.android.models.PaymentMethod
 import co.omise.android.models.Source
@@ -104,7 +105,7 @@ interface PaymentCreatorNavigation {
     fun navigateToInternetBankingChooser(allowedBanks: List<PaymentMethod>)
     fun navigateToInstallmentChooser(allowedInstalls: List<PaymentMethod>)
     fun navigateToInstallmentTermChooser(installment: PaymentMethod)
-    fun navigateToEContextForm()
+    fun navigateToEContextForm(eContext: SupportedEContext)
     fun createSourceFinished(source: Source)
 }
 
@@ -163,8 +164,8 @@ private class PaymentCreatorNavigationImpl(
         addFragmentToBackStack(fragment)
     }
 
-    override fun navigateToEContextForm() {
-        val fragment = EContextFormFragment.newInstance().apply {
+    override fun navigateToEContextForm(eContext: SupportedEContext) {
+        val fragment = EContextFormFragment.newInstance(eContext).apply {
             requester = this@PaymentCreatorNavigationImpl.requester
         }
         addFragmentToBackStack(fragment)

--- a/sdk/src/main/res/layout/fragment_econtext_form.xml
+++ b/sdk/src/main/res/layout/fragment_econtext_form.xml
@@ -92,7 +92,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/xlarge_margin"
-        android:enabled="true"
+        android:enabled="false"
         android:text="Next"
         tools:enabled="true" />
 </LinearLayout>

--- a/sdk/src/main/res/layout/fragment_econtext_form.xml
+++ b/sdk/src/main/res/layout/fragment_econtext_form.xml
@@ -29,10 +29,18 @@
         android:imeOptions="actionNext" />
 
     <TextView
+        android:id="@+id/text_full_name_error"
+        style="?attr/editTextErrorStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/xsmall_margin"
+        tools:text="Invalid input" />
+
+    <TextView
         style="?attr/editTextLabelStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/large_margin"
+        android:layout_marginTop="@dimen/small_margin"
         android:text="Email" />
 
     <co.omise.android.ui.OmiseEditText
@@ -41,9 +49,17 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:inputType="textEmailAddress"
-        android:nextFocusForward="@id/edit_phone"
+        android:nextFocusForward="@id/edit_phone_number"
         android:layout_marginTop="@dimen/small_margin"
         android:imeOptions="actionNext" />
+
+    <TextView
+        android:id="@+id/text_email_error"
+        style="?attr/editTextErrorStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/xsmall_margin"
+        tools:text="Invalid input" />
 
     <TextView
         style="?attr/editTextLabelStyle"
@@ -53,7 +69,7 @@
         android:text="Phone" />
 
     <co.omise.android.ui.OmiseEditText
-        android:id="@+id/edit_phone"
+        android:id="@+id/edit_phone_number"
         style="?android:attr/editTextStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -61,6 +77,14 @@
         android:nextFocusForward="@id/button_submit"
         android:layout_marginTop="@dimen/small_margin"
         android:imeOptions="actionDone" />
+
+    <TextView
+        android:id="@+id/text_phone_number_error"
+        style="?attr/editTextErrorStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/xsmall_margin"
+        tools:text="Invalid input" />
 
     <Button
         android:id="@+id/button_submit"

--- a/sdk/src/main/res/layout/fragment_econtext_form.xml
+++ b/sdk/src/main/res/layout/fragment_econtext_form.xml
@@ -1,98 +1,104 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="@dimen/xlarge_padding"
-    android:paddingBottom="@dimen/xlarge_padding"
-    android:paddingStart="@dimen/large_padding"
-    android:paddingLeft="@dimen/large_padding"
-    android:paddingEnd="@dimen/large_padding"
-    android:paddingRight="@dimen/large_padding"
-    android:background="?android:attr/windowBackground"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
-        style="?attr/editTextLabelStyle"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Full name" />
+        android:background="?android:attr/windowBackground"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/large_padding"
+        android:paddingLeft="@dimen/large_padding"
+        android:paddingTop="@dimen/xlarge_padding"
+        android:paddingEnd="@dimen/large_padding"
+        android:paddingRight="@dimen/large_padding"
+        android:paddingBottom="@dimen/xlarge_padding">
 
-    <co.omise.android.ui.OmiseEditText
-        android:id="@+id/edit_full_name"
-        style="?android:attr/editTextStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inputType="textPersonName"
-        android:layout_marginTop="@dimen/small_margin"
-        android:nextFocusForward="@id/edit_email"
-        android:imeOptions="actionNext" />
+        <TextView
+            style="?attr/editTextLabelStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/label_full_name" />
 
-    <TextView
-        android:id="@+id/text_full_name_error"
-        style="?attr/editTextErrorStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/xsmall_margin"
-        tools:text="Invalid input" />
+        <co.omise.android.ui.OmiseEditText
+            android:id="@+id/edit_full_name"
+            style="?android:attr/editTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/small_margin"
+            android:imeOptions="actionNext"
+            android:inputType="textPersonName"
+            android:nextFocusForward="@id/edit_email" />
 
-    <TextView
-        style="?attr/editTextLabelStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/small_margin"
-        android:text="Email" />
+        <TextView
+            android:id="@+id/text_full_name_error"
+            style="?attr/editTextErrorStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/xsmall_margin"
+            tools:text="Invalid input" />
 
-    <co.omise.android.ui.OmiseEditText
-        android:id="@+id/edit_email"
-        style="?android:attr/editTextStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inputType="textEmailAddress"
-        android:nextFocusForward="@id/edit_phone_number"
-        android:layout_marginTop="@dimen/small_margin"
-        android:imeOptions="actionNext" />
+        <TextView
+            style="?attr/editTextLabelStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/small_margin"
+            android:text="@string/label_email" />
 
-    <TextView
-        android:id="@+id/text_email_error"
-        style="?attr/editTextErrorStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/xsmall_margin"
-        tools:text="Invalid input" />
+        <co.omise.android.ui.OmiseEditText
+            android:id="@+id/edit_email"
+            style="?android:attr/editTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/small_margin"
+            android:imeOptions="actionNext"
+            android:inputType="textEmailAddress"
+            android:nextFocusForward="@id/edit_phone_number" />
 
-    <TextView
-        style="?attr/editTextLabelStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/large_margin"
-        android:text="Phone" />
+        <TextView
+            android:id="@+id/text_email_error"
+            style="?attr/editTextErrorStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/xsmall_margin"
+            tools:text="Invalid input" />
 
-    <co.omise.android.ui.OmiseEditText
-        android:id="@+id/edit_phone_number"
-        style="?android:attr/editTextStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inputType="phone"
-        android:nextFocusForward="@id/button_submit"
-        android:layout_marginTop="@dimen/small_margin"
-        android:imeOptions="actionDone" />
+        <TextView
+            style="?attr/editTextLabelStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/large_margin"
+            android:text="@string/label_phone_number" />
 
-    <TextView
-        android:id="@+id/text_phone_number_error"
-        style="?attr/editTextErrorStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/xsmall_margin"
-        tools:text="Invalid input" />
+        <co.omise.android.ui.OmiseEditText
+            android:id="@+id/edit_phone_number"
+            style="?android:attr/editTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/small_margin"
+            android:imeOptions="actionDone"
+            android:inputType="phone"
+            android:nextFocusForward="@id/button_submit" />
 
-    <Button
-        android:id="@+id/button_submit"
-        style="?android:attr/buttonStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/xlarge_margin"
-        android:enabled="false"
-        android:text="Next"
-        tools:enabled="true" />
-</LinearLayout>
+        <TextView
+            android:id="@+id/text_phone_number_error"
+            style="?attr/editTextErrorStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/xsmall_margin"
+            tools:text="Invalid input" />
+
+        <Button
+            android:id="@+id/button_submit"
+            style="?android:attr/buttonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/xlarge_margin"
+            android:enabled="false"
+            android:text="@string/button_next"
+            tools:enabled="true" />
+    </LinearLayout>
+
+</ScrollView>

--- a/sdk/src/main/res/layout/fragment_econtext_form.xml
+++ b/sdk/src/main/res/layout/fragment_econtext_form.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/xlarge_padding"
+    android:paddingBottom="@dimen/xlarge_padding"
+    android:paddingStart="@dimen/large_padding"
+    android:paddingLeft="@dimen/large_padding"
+    android:paddingEnd="@dimen/large_padding"
+    android:paddingRight="@dimen/large_padding"
+    android:background="?android:attr/windowBackground"
+    android:orientation="vertical">
+
+    <TextView
+        style="?attr/editTextLabelStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Full name" />
+
+    <co.omise.android.ui.OmiseEditText
+        android:id="@+id/edit_full_name"
+        style="?android:attr/editTextStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textPersonName"
+        android:layout_marginTop="@dimen/small_margin"
+        android:nextFocusForward="@id/edit_email"
+        android:imeOptions="actionNext" />
+
+    <TextView
+        style="?attr/editTextLabelStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/large_margin"
+        android:text="Email" />
+
+    <co.omise.android.ui.OmiseEditText
+        android:id="@+id/edit_email"
+        style="?android:attr/editTextStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textEmailAddress"
+        android:nextFocusForward="@id/edit_phone"
+        android:layout_marginTop="@dimen/small_margin"
+        android:imeOptions="actionNext" />
+
+    <TextView
+        style="?attr/editTextLabelStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/large_margin"
+        android:text="Phone" />
+
+    <co.omise.android.ui.OmiseEditText
+        android:id="@+id/edit_phone"
+        style="?android:attr/editTextStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="phone"
+        android:nextFocusForward="@id/button_submit"
+        android:layout_marginTop="@dimen/small_margin"
+        android:imeOptions="actionDone" />
+
+    <Button
+        android:id="@+id/button_submit"
+        style="?android:attr/buttonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/xlarge_margin"
+        android:enabled="true"
+        android:text="Next"
+        tools:enabled="true" />
+</LinearLayout>

--- a/sdk/src/main/res/values/dimens.xml
+++ b/sdk/src/main/res/values/dimens.xml
@@ -15,7 +15,12 @@
     <dimen name="large_margin">24dp</dimen>
     <dimen name="xlarge_margin">32dp</dimen>
 
+    <dimen name="xsmall_padding">4dp</dimen>
     <dimen name="small_padding">8dp</dimen>
+    <dimen name="medium_padding">16dp</dimen>
+    <dimen name="large_padding">24dp</dimen>
+    <dimen name="xlarge_padding">32dp</dimen>
+
     <dimen name="dialog_radius_size">10dp</dimen>
     <dimen name="edit_text_inset_padding">8dp</dimen>
     <dimen name="edit_text_height">44dp</dimen>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -9,6 +9,10 @@
     <string name="error_invalid_card_name">Card holder name is invalid</string>
     <string name="error_invalid_expiry_date">Card expiry date is invalid</string>
     <string name="error_invalid_security_code">CVV is invalid</string>
+    <string name="error_invalid_full_name">Customer name is invalid</string>
+    <string name="error_invalid_email">Email is invalid</string>
+    <string name="error_invalid_phone_number">Phone number is invalid</string>
+    <string name="error_invalid_unknown">Data is invalid</string>
     <string name="error_invalid">%1$s is invalid</string>
     <string name="error_required">%1$s is required</string>
 

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="not_available">(n/a)</string>
     <string name="button_pay">Pay</string>
+    <string name="button_next">Next</string>
     <string name="default_form_title">Credit Card</string>
     <string name="description_brand_logo">Card brand logo</string>
     <string name="error_api">Error: %1$s</string>
@@ -26,6 +27,9 @@
     <string name="label_card_name">Name on card</string>
     <string name="label_card_number">Card number</string>
     <string name="label_expiry_date">Expiry date</string>
+    <string name="label_full_name">Full name</string>
+    <string name="label_email">Email</string>
+    <string name="label_phone_number">Phone</string>
     <string name="label_security_code">Security code</string>
     <string name="menu_card_io">Scan from Camera</string>
     <string name="title_authorizing_payment">Authorizing Payment</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -33,5 +33,6 @@
     <string name="payment_chooser_title">Payment Methods</string>
     <string name="internet_banking_chooser_title">Internet Banking</string>
     <string name="installments_title">Installments</string>
+    <string name="econtext_title">EContext</string>
     <string name="menu_title_close">Close</string>
 </resources>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -33,6 +33,9 @@
     <string name="label_security_code">Security code</string>
     <string name="menu_card_io">Scan from Camera</string>
     <string name="title_authorizing_payment">Authorizing Payment</string>
+    <string name="title_convenience_store">Convenience Store</string>
+    <string name="title_pay_easy">Pay-easy</string>
+    <string name="title_netbanking">Netbanking</string>
     <string name="placeholder_security_code" translatable="false">CVV</string>
     <string name="hint_expiry_date" translatable="false">MM/YY</string>
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
+import co.omise.android.models.SupportedEContext
 import co.omise.android.models.Source
 import co.omise.android.utils.focus
 import com.nhaarman.mockitokotlin2.any
@@ -33,7 +34,7 @@ class EContextFormFragmentTest {
         on { currency }.doReturn("jpy")
     }
 
-    private val fragment = EContextFormFragment.newInstance().apply {
+    private val fragment = EContextFormFragment.newInstance(SupportedEContext.ConvenienceStore).apply {
         requester = mockRequester
     }
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
@@ -91,4 +91,18 @@ class EContextFormFragmentTest {
 
         onView(withId(R.id.button_submit)).check(matches(not(isEnabled())))
     }
+
+    @Test
+    fun disableForm_disableFormWhenRequestSent() {
+        onView(withId(R.id.edit_full_name)).perform(typeText("John Doe"), pressImeActionButton())
+        onView(withId(R.id.edit_email)).perform(typeText("johndoe@mail.com"), pressImeActionButton())
+        onView(withId(R.id.edit_phone_number)).perform(typeText("0812345678"), pressImeActionButton())
+
+        onView(withId(R.id.button_submit)).perform(click())
+
+        onView(withId(R.id.edit_full_name)).check(matches(not(isEnabled())))
+        onView(withId(R.id.edit_email)).check(matches(not(isEnabled())))
+        onView(withId(R.id.edit_phone_number)).check(matches(not(isEnabled())))
+        onView(withId(R.id.button_submit)).check(matches(not(isEnabled())))
+    }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
@@ -1,0 +1,94 @@
+package co.omise.android.ui
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.pressImeActionButton
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import co.omise.android.R
+import co.omise.android.models.Source
+import co.omise.android.utils.focus
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.hamcrest.CoreMatchers.not
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp")
+class EContextFormFragmentTest {
+
+    private val mockRequester: PaymentCreatorRequester<Source> = mock {
+        on { amount }.doReturn(40000L)
+        on { currency }.doReturn("jpy")
+    }
+
+    private val fragment = EContextFormFragment.newInstance().apply {
+        requester = mockRequester
+    }
+
+    @Before
+    fun setUp() {
+        ActivityScenario.launch(TestFragmentActivity::class.java).onActivity {
+            it.replaceFragment(fragment)
+        }
+
+        onView(withText(R.string.econtext_title)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun clickSubmitButton_requestCreatingSource() {
+        onView(withId(R.id.edit_full_name)).perform(typeText("John Doe"), pressImeActionButton())
+        onView(withId(R.id.edit_email)).perform(typeText("johndoe@mail.com"), pressImeActionButton())
+        onView(withId(R.id.edit_phone_number)).perform(typeText("0812345678"), pressImeActionButton())
+
+        onView(withId(R.id.button_submit)).perform(click())
+
+        verify(mockRequester).request(any(), any())
+    }
+
+    @Test
+    fun invalidErrorTexts_showErrorTexts() {
+        onView(withId(R.id.edit_full_name)).perform(focus(true), focus(false))
+
+        onView(withId(R.id.text_full_name_error)).check(matches(withText(R.string.error_invalid_full_name)))
+
+
+        onView(withId(R.id.edit_email)).perform(focus(true), focus(false))
+
+        onView(withId(R.id.text_email_error)).check(matches(withText(R.string.error_invalid_email)))
+
+
+        onView(withId(R.id.edit_phone_number)).perform(focus(true), focus(false))
+
+        onView(withId(R.id.text_phone_number_error)).check(matches(withText(R.string.error_invalid_phone_number)))
+    }
+
+    @Test
+    fun validInputs_enableSubmitButton() {
+        onView(withId(R.id.edit_full_name)).perform(typeText("John Doe"), pressImeActionButton())
+        onView(withId(R.id.edit_email)).perform(typeText("johndoe@mail.com"), pressImeActionButton())
+        onView(withId(R.id.edit_phone_number)).perform(typeText("0812345678"), pressImeActionButton())
+
+        onView(withId(R.id.button_submit)).check(matches(isEnabled()))
+    }
+
+    @Test
+    fun invalidInputs_disableSubmitButton() {
+        onView(withId(R.id.edit_full_name)).perform(typeText(""), pressImeActionButton())
+        onView(withId(R.id.edit_email)).perform(typeText(""), pressImeActionButton())
+        onView(withId(R.id.edit_phone_number)).perform(typeText(""), pressImeActionButton())
+
+        onView(withId(R.id.button_submit)).check(matches(not(isEnabled())))
+    }
+}

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
@@ -3,8 +3,9 @@ package co.omise.android.ui
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
 import co.omise.android.models.PaymentMethod

--- a/sdk/src/sharedTest/java/co/omise/android/utils/ViewUtils.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/utils/ViewUtils.kt
@@ -1,0 +1,28 @@
+package co.omise.android.utils
+
+import android.view.View
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Matcher
+
+
+fun focus(isFocus: Boolean): ViewAction =
+        object : ViewAction {
+            override fun getDescription(): String = "Set focus status to a View."
+
+            override fun getConstraints(): Matcher<View> =
+                    allOf(isDisplayed(), isDescendantOfA(isAssignableFrom(View::class.java)))
+
+            override fun perform(uiController: UiController?, view: View?) {
+                if (isFocus) {
+                    view?.requestFocus()
+                } else {
+                    view?.clearFocus()
+                }
+                uiController?.loopMainThreadUntilIdle()
+            }
+        }


### PR DESCRIPTION
### Objective

To able users create a payment from Convenience Store / Pay-easy / Netbanking in the payment chooser page.

### Description of changes

When the user pressed Convenience Store / Pay-easy / Netbanking in the payment chooser page, it will display a form that required full-name, email, phone number. When the user pressed the next button, it will send a request to create a source with information in the form.

### QA

When the user entered valid information, it will send a request and return a source object.

If there is invalid information, the submit button will disable to press til the user enter valid data.

![create-source-from-econtext](https://user-images.githubusercontent.com/2638321/64946177-702ce900-d89c-11e9-8b72-8b5883b25278.gif)
