### PR TITLE
Create payment from Alipay / Bill payment Tesco Lotus

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import co.omise.android.R
 import co.omise.android.models.BackendType
 import co.omise.android.models.Capability
+import co.omise.android.models.Source
 import co.omise.android.models.SupportedEContext
 import co.omise.android.models.SourceType
 import co.omise.android.models.backendType
@@ -15,6 +16,7 @@ import co.omise.android.models.backendType
 class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
 
     var navigation: PaymentCreatorNavigation? = null
+    var requester: PaymentCreatorRequester<Source>? = null
     val capability: Capability? by lazy { arguments?.getParcelable<Capability>(EXTRA_CAPABILITY) }
 
     override fun listItems(): List<PaymentChooserItem> {
@@ -40,7 +42,7 @@ class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
             PaymentChooserItem.ConvenienceStore -> navigation?.navigateToEContextForm(SupportedEContext.ConvenienceStore)
             PaymentChooserItem.PayEasy -> navigation?.navigateToEContextForm(SupportedEContext.PayEasy)
             PaymentChooserItem.Netbanking -> navigation?.navigateToEContextForm(SupportedEContext.Netbanking)
-            PaymentChooserItem.Alipay -> TODO()
+            PaymentChooserItem.Alipay -> sendRequest(SourceType.Alipay)
         }
     }
 
@@ -64,6 +66,17 @@ class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
             }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun sendRequest(sourceType: SourceType) {
+        val requester = requester ?: return
+
+        val request = Source.CreateSourceRequestBuilder(requester.amount, requester.currency, sourceType).build()
+        view?.let { setAllViewsEnabled(it, false) }
+
+        requester.request(request) {
+            view?.let { setAllViewsEnabled(it, true) }
+        }
     }
 
     private fun getPaymentChoosersFrom(capability: Capability): List<PaymentChooserItem> {

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -38,7 +38,7 @@ class PaymentChooserFragment : OmiseListFragment<PaymentChooserItem>() {
                             ?.filter { it.backendType is BackendType.Source && (it.backendType as BackendType.Source).sourceType is SourceType.InternetBanking }
                             .orEmpty()
             )
-            PaymentChooserItem.TescoLotus -> TODO()
+            PaymentChooserItem.TescoLotus -> sendRequest(SourceType.BillPaymentTescoLotus)
             PaymentChooserItem.ConvenienceStore -> navigation?.navigateToEContextForm(SupportedEContext.ConvenienceStore)
             PaymentChooserItem.PayEasy -> navigation?.navigateToEContextForm(SupportedEContext.PayEasy)
             PaymentChooserItem.Netbanking -> navigation?.navigateToEContextForm(SupportedEContext.Netbanking)

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -132,6 +132,7 @@ private class PaymentCreatorNavigationImpl(
     override fun navigateToPaymentChooser(capability: Capability) {
         val fragment = PaymentChooserFragment.newInstance(capability).apply {
             navigation = this@PaymentCreatorNavigationImpl
+            requester = this@PaymentCreatorNavigationImpl.requester
         }
         addFragmentToBackStack(fragment)
     }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -30,6 +30,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class CreditCardActivityTest {

--- a/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/EContextFormFragmentTest.kt
@@ -12,8 +12,8 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
-import co.omise.android.models.SupportedEContext
 import co.omise.android.models.Source
+import co.omise.android.models.SupportedEContext
 import co.omise.android.utils.focus
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -23,10 +23,8 @@ import org.hamcrest.CoreMatchers.not
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
-@Config(qualifiers = "w360dp-h640dp")
 class EContextFormFragmentTest {
 
     private val mockRequester: PaymentCreatorRequester<Source> = mock {
@@ -44,7 +42,7 @@ class EContextFormFragmentTest {
             it.replaceFragment(fragment)
         }
 
-        onView(withText(R.string.econtext_title)).check(matches(isDisplayed()))
+        onView(withText(R.string.title_convenience_store)).check(matches(isDisplayed()))
     }
 
     @Test

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -32,11 +32,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 
 @RunWith(AndroidJUnit4::class)
-@Config(qualifiers = "w360dp-h640dp")
 class PaymentChooserFragmentTest {
     private lateinit var scenario: ActivityScenario<TestFragmentActivity>
     private lateinit var fragment: PaymentChooserFragment
@@ -84,7 +82,7 @@ class PaymentChooserFragmentTest {
     }
 
     @After
-    fun tearDown(){
+    fun tearDown() {
         Intents.release()
     }
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -13,27 +13,38 @@ import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
 import co.omise.android.models.Capability
 import co.omise.android.models.PaymentMethod
+import co.omise.android.models.Source
 import co.omise.android.utils.itemCount
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 
 @RunWith(AndroidJUnit4::class)
+@Config(qualifiers = "w360dp-h640dp")
 class PaymentChooserFragmentTest {
     private lateinit var scenario: ActivityScenario<TestFragmentActivity>
     private lateinit var fragment: PaymentChooserFragment
     private val mockNavigation: PaymentCreatorNavigation = mock()
+    private val mockRequester: PaymentCreatorRequester<Source> = mock {
+        on { amount }.doReturn(500000L)
+        on { currency }.doReturn("thb")
+    }
 
     @get:Rule
     val intentRule = IntentsTestRule<TestFragmentActivity>(TestFragmentActivity::class.java)
@@ -61,6 +72,7 @@ class PaymentChooserFragmentTest {
 
         fragment = PaymentChooserFragment.newInstance(capability).apply {
             navigation = mockNavigation
+            requester = mockRequester
         }
 
         intending(hasComponent(hasClassName(TestFragmentActivity::class.java.name)))
@@ -122,5 +134,23 @@ class PaymentChooserFragmentTest {
                 PaymentMethod(name = "installment_ktc")
         )
         verify(fragment.navigation)?.navigateToInstallmentChooser(expectedMethods)
+    }
+
+    @Test
+    fun clickBillPaymentTescoLotusPaymentMethod_sendRequestToCreateSource() {
+        onView(withId(R.id.recycler_view))
+                .perform(actionOnItemAtPosition<OmiseItemViewHolder>(3, click()))
+
+        onView(withId(R.id.recycler_view)).check(matches(not(isEnabled())))
+        verify(mockRequester).request(any(), any())
+    }
+
+    @Test
+    fun clickAlipayPaymentMethod_sendRequestToCreateSource() {
+        onView(withId(R.id.recycler_view))
+                .perform(actionOnItemAtPosition<OmiseItemViewHolder>(7, click()))
+
+        onView(withId(R.id.recycler_view)).check(matches(not(isEnabled())))
+        verify(mockRequester).request(any(), any())
     }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -8,10 +8,10 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
-import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -27,9 +27,9 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import org.hamcrest.CoreMatchers.not
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -46,11 +46,10 @@ class PaymentChooserFragmentTest {
         on { currency }.doReturn("thb")
     }
 
-    @get:Rule
-    val intentRule = IntentsTestRule<TestFragmentActivity>(TestFragmentActivity::class.java)
-
     @Before
     fun setUp() {
+        Intents.init()
+
         val paymentMethods = listOf(
                 PaymentMethod(name = "card"),
                 PaymentMethod(name = "installment_bay"),
@@ -82,6 +81,11 @@ class PaymentChooserFragmentTest {
             it.startActivityForResult(Intent(it, TestFragmentActivity::class.java), 0)
             it.replaceFragment(fragment)
         }
+    }
+
+    @After
+    fun tearDown(){
+        Intents.release()
     }
 
     @Test

--- a/sdk/src/test/resources/robolectric.properties
+++ b/sdk/src/test/resources/robolectric.properties
@@ -1,0 +1,1 @@
+qualifiers=w360dp-h640dp


### PR DESCRIPTION
### Objective

To able users to send a request to create a source object from Alipay and Bill Payment Tesco Lotus.

### Description of changes

Set the event when the user press on Alipay or Bill Payment Tesco Lotus from the payment chooser page. It will send a request with the source type to create a source object.

### QA

When the user press on Alipay or Bill Payment Tesco Lotus it will return a source object.

![create-source-from-alipay-and-tesco](https://user-images.githubusercontent.com/2638321/65016998-d757a580-d94f-11e9-849d-ebde497371ef.gif)
