### PR TITLE
Added ItemDecoration to RecyclerView.

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/OmiseListFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseListFragment.kt
@@ -1,13 +1,19 @@
 package co.omise.android.ui
 
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import co.omise.android.R
 import kotlinx.android.synthetic.main.fragment_list.recycler_view
 
@@ -35,6 +41,7 @@ abstract class OmiseListFragment<T : OmiseListItem> : OmiseFragment() {
 
         val layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
         recyclerView.layoutManager = layoutManager
+        context?.let { recyclerView.addItemDecoration(OmiseItemDecoration(it)) }
         recyclerView.adapter = adapter
     }
 
@@ -81,4 +88,45 @@ interface OmiseListItem {
 
 interface OmiseListItemClickListener {
     fun onClick(item: OmiseListItem)
+}
+
+private class OmiseItemDecoration(val context: Context) : RecyclerView.ItemDecoration() {
+    private val divider: Drawable? = AppCompatResources.getDrawable(context, R.drawable.item_decoration)
+    override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
+        val divider = divider ?: return
+
+        val childCount = parent.childCount
+
+        loop@ for (i in 0 until childCount) {
+            val view = parent.getChildAt(i)
+            val pos = parent.getChildAdapterPosition(view)
+
+            if (pos == NO_POSITION) {
+                continue@loop
+            }
+
+            val params = view.layoutParams as RecyclerView.LayoutParams
+
+            val titleText = view.findViewById<TextView>(R.id.text_item_title)
+            val left = titleText.left
+            val right = parent.width
+            val top = view.bottom + params.bottomMargin
+            val bottom = top + divider.intrinsicHeight
+            divider.setBounds(left, top, right, bottom)
+            divider.draw(c)
+        }
+    }
+
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        super.getItemOffsets(outRect, view, parent, state)
+
+        val divider = divider ?: return
+
+        val pos = parent.getChildAdapterPosition(view)
+        if (pos == NO_POSITION) {
+            return
+        }
+
+        outRect.bottom = divider.intrinsicHeight
+    }
 }


### PR DESCRIPTION
### Objective

To put the line diver between items in RecyclerView.

### Description of changes

In this OR created `OmiseItemDecoration` class that set the starting line from title to end of the item. And set it to OmiseListFragment's recyclerView. Every children class will automatically apply this item decoration.

### QA

All pages that have list view should show line divider between items.

![Screenshot_1568704572](https://user-images.githubusercontent.com/2638321/65020058-931bd380-d956-11e9-8d45-a2742f53f4aa.png)
![Screenshot_1568704576](https://user-images.githubusercontent.com/2638321/65020613-b4c98a80-d957-11e9-98f0-2e65527ddc55.png)
