### PR TITLE
Payment creator handle error messages

### DIFF
--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -12,14 +12,26 @@ fun APIError.getMessageFromResources(res: Resources): String = result@ when (err
                 InvalidCardReason.InvalidCardNumber -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
                 InvalidCardReason.InvalidExpirationDate -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
                 InvalidCardReason.EmptyCardHolderName -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
-                InvalidCardReason.UnsupportedBrand -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
+                InvalidCardReason.UnsupportedBrand -> res.getString(R.string.error_api_invalid_card_unsupported_brand)
                 is InvalidCardReason.Unknown -> res.getString(R.string.error_required, it.message)
             }
         }
     }
     is APIErrorCode.BadRequest -> {
         return@result (errorCode as APIErrorCode.BadRequest).reasons.forEach {
-
+            return when (it) {
+                is BadRequestReason.AmountIsGreaterThanValidAmount -> res.getString(R.string.error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount, "10000 thb")
+                is BadRequestReason.AmountIsLessThanValidAmount -> res.getString(R.string.error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount, "10000 thb")
+                BadRequestReason.InvalidCurrency -> res.getString(R.string.error_api_bad_request_invalid_currency)
+                BadRequestReason.EmptyName -> res.getString(R.string.error_api_bad_request_empty_name)
+                is BadRequestReason.NameIsTooLong -> res.getString(R.string.error_api_bad_request_name_is_too_long_with_valid_length, 1)
+                BadRequestReason.InvalidName -> res.getString(R.string.error_api_bad_request_invalid_name)
+                BadRequestReason.InvalidEmail -> res.getString(R.string.error_api_bad_request_invalid_email)
+                BadRequestReason.InvalidPhoneNumber -> res.getString(R.string.error_api_bad_request_invalid_phone_number)
+                BadRequestReason.TypeNotSupported -> res.getString(R.string.error_api_bad_request_type_not_supported)
+                BadRequestReason.CurrencyNotSupported -> res.getString(R.string.error_api_bad_request_currency_not_supported)
+                is BadRequestReason.Unknown -> res.getString(R.string.error_api_bad_request_other, it.message)
+            }
         }
     }
     APIErrorCode.AuthenticationFailure -> res.getString(R.string.error_api_authentication_failure)

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -7,33 +7,45 @@ import co.omise.android.models.APIError
 
 fun APIError.getMessageFromResources(res: Resources): String = result@ when (errorCode) {
     is APIErrorCode.InvalidCard -> {
-        return@result message?.split(",")?.forEach {
-            return when (val errorReason = InvalidCardReason.creator(it)) {
+       return@result (errorCode as APIErrorCode.InvalidCard).reasons.forEach {
+            return when (it) {
                 InvalidCardReason.InvalidCardNumber -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
                 InvalidCardReason.InvalidExpirationDate -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
                 InvalidCardReason.EmptyCardHolderName -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
                 InvalidCardReason.UnsupportedBrand -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
-                is InvalidCardReason.Unknown -> res.getString(R.string.error_required, errorReason.message)
+                is InvalidCardReason.Unknown -> res.getString(R.string.error_required, it.message)
             }
-        } ?: return@result res.getString(R.string.error_required, message)
+        }
+    }
+    is APIErrorCode.BadRequest -> {
+        return@result (errorCode as APIErrorCode.BadRequest).reasons.forEach {
+
+        }
     }
     APIErrorCode.AuthenticationFailure -> res.getString(R.string.error_api_authentication_failure)
     else -> res.getString(R.string.error_required, message)
 }
 
 val APIError.errorCode: APIErrorCode
-    get() = when (code) {
-        "authentication_failure" -> APIErrorCode.AuthenticationFailure
-        "invalid_card" -> APIErrorCode.InvalidCard(emptyList())
-        "bad_request" -> APIErrorCode.BadRequest(emptyList())
-        else -> APIErrorCode.Unknown(code)
-    }
+    get() = APIErrorCode.creator(code.orEmpty(), message.orEmpty())
 
 sealed class APIErrorCode {
     object AuthenticationFailure : APIErrorCode()
-    data class InvalidCard(val reasons: List<BadRequestReason>) : APIErrorCode()
+    data class InvalidCard(val reasons: List<InvalidCardReason>) : APIErrorCode()
     data class BadRequest(val reasons: List<BadRequestReason>) : APIErrorCode()
-    data class Unknown(val errorCode: String?) : APIErrorCode()
+    data class Unknown(val code: String?) : APIErrorCode()
+
+    companion object {
+        fun creator(code: String, message: String): APIErrorCode {
+            val messages = message.split(",")
+            return when (code) {
+                "authentication_failure" -> AuthenticationFailure
+                "invalid_card" -> InvalidCard(messages.map { InvalidCardReason.creator(it) })
+                "bad_request" -> BadRequest(messages.map { BadRequestReason.creator(it) })
+                else -> Unknown(code)
+            }
+        }
+    }
 }
 
 sealed class InvalidCardReason {
@@ -44,16 +56,44 @@ sealed class InvalidCardReason {
     data class Unknown(val message: String?) : InvalidCardReason()
 
     companion object {
-        fun creator(errorMessage: String): InvalidCardReason = when {
-            errorMessage.isContains("number") -> InvalidCardNumber
-            errorMessage.isContains("expiration") -> InvalidExpirationDate
-            errorMessage.isContains("name") -> EmptyCardHolderName
-            errorMessage.isContains("brand") -> UnsupportedBrand
-            else -> Unknown(errorMessage)
+        fun creator(message: String): InvalidCardReason = when {
+            message.isContains("number") -> InvalidCardNumber
+            message.isContains("expiration") -> InvalidExpirationDate
+            message.isContains("name") -> EmptyCardHolderName
+            message.isContains("brand") -> UnsupportedBrand
+            else -> Unknown(message)
         }
     }
 }
 
 sealed class BadRequestReason {
+    data class AmountIsGreaterThanValidAmount(val validAmount: Long, val currency: String) : BadRequestReason()
+    data class AmountIsLessThanValidAmount(val validAmount: Long, val currency: String) : BadRequestReason()
+    object InvalidCurrency : BadRequestReason()
+    object EmptyName : BadRequestReason()
+    data class NameIsTooLong(val maximum: Int) : BadRequestReason()
+    object InvalidName : BadRequestReason()
+    object InvalidEmail : BadRequestReason()
+    object InvalidPhoneNumber : BadRequestReason()
+    object TypeNotSupported : BadRequestReason()
+    object CurrencyNotSupported : BadRequestReason()
+    data class Unknown(val message: String?) : BadRequestReason()
 
+    companion object {
+        fun creator(message: String): BadRequestReason = when {
+            message.isContains("currency must be") -> InvalidCurrency
+            // when {
+            // AmountIsGreaterThanValidAmount
+            // AmountIsLessThanValidAmount
+            // }
+            message.isContains("type") -> TypeNotSupported
+            message.isContains("currency") -> CurrencyNotSupported
+            message.isContains("name") && message.isContains("blank") -> EmptyName
+            message.startsWith("name is too long") -> NameIsTooLong(0)
+            message.isContains("name") -> InvalidName
+            message.isContains("email") -> InvalidEmail
+            message.isContains("phone") -> InvalidPhoneNumber
+            else -> Unknown(message)
+        }
+    }
 }

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -3,6 +3,7 @@ package co.omise.android.extensions
 import android.content.res.Resources
 import co.omise.android.R
 import co.omise.android.models.APIError
+import co.omise.android.models.Amount
 
 
 fun APIError.getMessageFromResources(res: Resources): String = result@ when (errorCode) {
@@ -21,12 +22,14 @@ fun APIError.getMessageFromResources(res: Resources): String = result@ when (err
         return@result (errorCode as APIErrorCode.BadRequest).reasons.forEach {
             return when (it) {
                 is BadRequestReason.AmountIsGreaterThanValidAmount -> if (it?.validAmount != null && !it.currency.isNullOrEmpty()) {
-                    res.getString(R.string.error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount, it?.validAmount, it?.currency)
+                    val amount = Amount(it.validAmount, it.currency)
+                    res.getString(R.string.error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount, amount.toAmountString())
                 } else {
                     res.getString(R.string.error_api_bad_request_amount_is_greater_than_valid_amount_without_valid_amount)
                 }
                 is BadRequestReason.AmountIsLessThanValidAmount -> if (it.validAmount != null && !it.currency.isNullOrEmpty()) {
-                    res.getString(R.string.error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount, it?.validAmount, it?.currency)
+                    val amount = Amount(it.validAmount, it.currency)
+                    res.getString(R.string.error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount, amount.toAmountString())
                 } else {
                     res.getString(R.string.error_api_bad_request_amount_is_less_than_valid_amount_without_valid_amount)
                 }

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -5,16 +5,55 @@ import co.omise.android.R
 import co.omise.android.models.APIError
 
 
-fun APIError.getMessageFromResources(res: Resources): String = when (code) {
-    "invalid_card" -> {
-        when {
-            message.isContains("number") -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
-            message.isContains("expiration") -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
-            message.isContains("name") -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
-            message.isContains("brand") -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
-            else -> res.getString(R.string.error_required, message)
+fun APIError.getMessageFromResources(res: Resources): String = result@ when (errorCode) {
+    is APIErrorCode.InvalidCard -> {
+        return@result message?.split(",")?.forEach {
+            return when (val errorReason = InvalidCardReason.creator(it)) {
+                InvalidCardReason.InvalidCardNumber -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
+                InvalidCardReason.InvalidExpirationDate -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
+                InvalidCardReason.EmptyCardHolderName -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
+                InvalidCardReason.UnsupportedBrand -> res.getString(R.string.error_api_invalid_card_unsopported_brand)
+                is InvalidCardReason.Unknown -> res.getString(R.string.error_required, errorReason.message)
+            }
+        } ?: return@result res.getString(R.string.error_required, message)
+    }
+    APIErrorCode.AuthenticationFailure -> res.getString(R.string.error_api_authentication_failure)
+    else -> res.getString(R.string.error_required, message)
+}
+
+val APIError.errorCode: APIErrorCode
+    get() = when (code) {
+        "authentication_failure" -> APIErrorCode.AuthenticationFailure
+        "invalid_card" -> APIErrorCode.InvalidCard(emptyList())
+        "bad_request" -> APIErrorCode.BadRequest(emptyList())
+        else -> APIErrorCode.Unknown(code)
+    }
+
+sealed class APIErrorCode {
+    object AuthenticationFailure : APIErrorCode()
+    data class InvalidCard(val reasons: List<BadRequestReason>) : APIErrorCode()
+    data class BadRequest(val reasons: List<BadRequestReason>) : APIErrorCode()
+    data class Unknown(val errorCode: String?) : APIErrorCode()
+}
+
+sealed class InvalidCardReason {
+    object InvalidCardNumber : InvalidCardReason()
+    object InvalidExpirationDate : InvalidCardReason()
+    object EmptyCardHolderName : InvalidCardReason()
+    object UnsupportedBrand : InvalidCardReason()
+    data class Unknown(val message: String?) : InvalidCardReason()
+
+    companion object {
+        fun creator(errorMessage: String): InvalidCardReason = when {
+            errorMessage.isContains("number") -> InvalidCardNumber
+            errorMessage.isContains("expiration") -> InvalidExpirationDate
+            errorMessage.isContains("name") -> EmptyCardHolderName
+            errorMessage.isContains("brand") -> UnsupportedBrand
+            else -> Unknown(errorMessage)
         }
     }
-    "authentication_failure" -> res.getString(R.string.error_api_authentication_failure)
-    else -> res.getString(R.string.error_required, message)
+}
+
+sealed class BadRequestReason {
+
 }

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -35,6 +35,7 @@ fun APIError.getMessageFromResources(res: Resources): String = result@ when (err
         }
     }
     APIErrorCode.AuthenticationFailure -> res.getString(R.string.error_api_authentication_failure)
+    APIErrorCode.ServiceNotFound -> res.getString(R.string.error_api_service_not_found)
     else -> res.getString(R.string.error_required, message)
 }
 
@@ -45,6 +46,7 @@ sealed class APIErrorCode {
     object AuthenticationFailure : APIErrorCode()
     data class InvalidCard(val reasons: List<InvalidCardReason>) : APIErrorCode()
     data class BadRequest(val reasons: List<BadRequestReason>) : APIErrorCode()
+    object ServiceNotFound : APIErrorCode()
     data class Unknown(val code: String?) : APIErrorCode()
 
     companion object {
@@ -56,6 +58,7 @@ sealed class APIErrorCode {
                 "authentication_failure" -> AuthenticationFailure
                 "invalid_card" -> InvalidCard(messages.map { InvalidCardReason.creator(it) })
                 "bad_request" -> BadRequest(messages.map { BadRequestReason.creator(it) })
+                "service_not_found" -> ServiceNotFound
                 else -> Unknown(code)
             }
         }

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -43,7 +43,7 @@ fun APIError.getMessageFromResources(res: Resources): String = when (errorCode) 
                 BadRequestReason.TypeNotSupported -> res.getString(R.string.error_api_bad_request_type_not_supported)
                 BadRequestReason.CurrencyNotSupported -> res.getString(R.string.error_api_bad_request_currency_not_supported)
                 is BadRequestReason.Unknown -> res.getString(R.string.error_api_bad_request_other, message)
-                else -> res.getString(R.string.error_required, message)
+                else -> res.getString(R.string.error_api, message)
             }
         }
     }

--- a/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/APIErrorExtensions.kt
@@ -6,42 +6,44 @@ import co.omise.android.models.APIError
 import co.omise.android.models.Amount
 
 
-fun APIError.getMessageFromResources(res: Resources): String = result@ when (errorCode) {
+fun APIError.getMessageFromResources(res: Resources): String = when (errorCode) {
     is APIErrorCode.InvalidCard -> {
-        return@result (errorCode as APIErrorCode.InvalidCard).reasons.forEach {
-            return when (it) {
+        (errorCode as APIErrorCode.InvalidCard).reasons.firstOrNull().run {
+            when (this) {
                 InvalidCardReason.InvalidCardNumber -> res.getString(R.string.error_api_invalid_card_invalid_card_number)
                 InvalidCardReason.InvalidExpirationDate -> res.getString(R.string.error_api_invalid_card_invalid_expiry_date)
                 InvalidCardReason.EmptyCardHolderName -> res.getString(R.string.error_api_invalid_card_empty_card_holder_name)
                 InvalidCardReason.UnsupportedBrand -> res.getString(R.string.error_api_invalid_card_unsupported_brand)
-                is InvalidCardReason.Unknown -> res.getString(R.string.error_required, it.message)
+                is InvalidCardReason.Unknown -> res.getString(R.string.error_required, message)
+                else -> res.getString(R.string.error_required, message)
             }
         }
     }
     is APIErrorCode.BadRequest -> {
-        return@result (errorCode as APIErrorCode.BadRequest).reasons.forEach {
-            return when (it) {
-                is BadRequestReason.AmountIsGreaterThanValidAmount -> if (it?.validAmount != null && !it.currency.isNullOrEmpty()) {
-                    val amount = Amount(it.validAmount, it.currency)
+        (errorCode as APIErrorCode.BadRequest).reasons.firstOrNull().run {
+            when (this) {
+                is BadRequestReason.AmountIsGreaterThanValidAmount -> if (validAmount != null && !currency.isNullOrEmpty()) {
+                    val amount = Amount(validAmount, currency)
                     res.getString(R.string.error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount, amount.toAmountString())
                 } else {
                     res.getString(R.string.error_api_bad_request_amount_is_greater_than_valid_amount_without_valid_amount)
                 }
-                is BadRequestReason.AmountIsLessThanValidAmount -> if (it.validAmount != null && !it.currency.isNullOrEmpty()) {
-                    val amount = Amount(it.validAmount, it.currency)
+                is BadRequestReason.AmountIsLessThanValidAmount -> if (validAmount != null && !currency.isNullOrEmpty()) {
+                    val amount = Amount(validAmount, currency)
                     res.getString(R.string.error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount, amount.toAmountString())
                 } else {
                     res.getString(R.string.error_api_bad_request_amount_is_less_than_valid_amount_without_valid_amount)
                 }
                 BadRequestReason.InvalidCurrency -> res.getString(R.string.error_api_bad_request_invalid_currency)
                 BadRequestReason.EmptyName -> res.getString(R.string.error_api_bad_request_empty_name)
-                is BadRequestReason.NameIsTooLong -> res.getString(R.string.error_api_bad_request_name_is_too_long_with_valid_length, it.maximum)
+                is BadRequestReason.NameIsTooLong -> res.getString(R.string.error_api_bad_request_name_is_too_long_with_valid_length, maximum)
                 BadRequestReason.InvalidName -> res.getString(R.string.error_api_bad_request_invalid_name)
                 BadRequestReason.InvalidEmail -> res.getString(R.string.error_api_bad_request_invalid_email)
                 BadRequestReason.InvalidPhoneNumber -> res.getString(R.string.error_api_bad_request_invalid_phone_number)
                 BadRequestReason.TypeNotSupported -> res.getString(R.string.error_api_bad_request_type_not_supported)
                 BadRequestReason.CurrencyNotSupported -> res.getString(R.string.error_api_bad_request_currency_not_supported)
-                is BadRequestReason.Unknown -> res.getString(R.string.error_api_bad_request_other, it.message)
+                is BadRequestReason.Unknown -> res.getString(R.string.error_api_bad_request_other, message)
+                else -> res.getString(R.string.error_required, message)
             }
         }
     }

--- a/sdk/src/main/java/co/omise/android/models/Amount.kt
+++ b/sdk/src/main/java/co/omise/android/models/Amount.kt
@@ -1,0 +1,15 @@
+package co.omise.android.models
+
+
+data class Amount(val amount: Long, val currency: String) {
+
+    val localAmount: Double
+        get() = when (currency.toLowerCase()) {
+            "jpy" -> amount.toDouble()
+            else -> amount / 100.0
+        }
+
+    fun toAmountString(): String {
+        return "$localAmount ${currency.toUpperCase()}"
+    }
+}

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -18,7 +18,7 @@
     <string name="error_api_invalid_card_invalid_card_number">無効なカード番号</string>
     <string name="error_api_invalid_card_invalid_expiry_date">無効なカード有効期限</string>
     <string name="error_api_invalid_card_empty_card_holder_name">無効なカード所有者名</string>
-    <string name="error_api_invalid_card_unsopported_brand">サポートされていないカード会社です</string>
+    <string name="error_api_invalid_card_unsupported_brand">サポートされていないカード会社です</string>
 
     <string name="error_unknown">原因不明のエラーです。. (%1$s)</string>
     <string name="label_card_name">カード名義</string>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -18,7 +18,7 @@
     <string name="error_api_invalid_card_invalid_card_number">หมายเลขบัตรไม่ถูกต้อง</string>
     <string name="error_api_invalid_card_invalid_expiry_date">วันหมดอายุบัตรไม่ถูกต้อง</string>
     <string name="error_api_invalid_card_empty_card_holder_name">ชื่อผู้ถือบัตรไม่ถูกต้อง</string>
-    <string name="error_api_invalid_card_unsopported_brand">บัตรเครดิตไม่รองรับ</string>
+    <string name="error_api_invalid_card_unsupported_brand">บัตรเครดิตไม่รองรับ</string>
 
     <string name="error_unknown">เกิดข้อผิดพลาด (%1$s)</string>
     <string name="label_card_name">ชื่อผู้ถือบัตร</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -23,9 +23,9 @@
     <string name="error_api_invalid_card_empty_card_holder_name">Invalid card holder name</string>
     <string name="error_api_invalid_card_unsupported_brand">Unsupported card brand</string>
 
-    <string name="error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount">Amount exceeds the valid amount of %d %s</string>
+    <string name="error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount">Amount exceeds the valid amount of %s</string>
     <string name="error_api_bad_request_amount_is_greater_than_valid_amount_without_valid_amount">Amount exceeds the valid amount</string>
-    <string name="error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount">Amount is less than the valid amount of %d %s</string>
+    <string name="error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount">Amount is less than the valid amount of %s</string>
     <string name="error_api_bad_request_amount_is_less_than_valid_amount_without_valid_amount">Amount is less than the valid amount</string>
     <string name="error_api_bad_request_currency_not_supported">The currency is not supported by this account</string>
     <string name="error_api_bad_request_empty_name">The customer name is empty</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -21,7 +21,22 @@
     <string name="error_api_invalid_card_invalid_card_number">Invalid card number</string>
     <string name="error_api_invalid_card_invalid_expiry_date">Invalid card expiration date</string>
     <string name="error_api_invalid_card_empty_card_holder_name">Invalid card holder name</string>
-    <string name="error_api_invalid_card_unsopported_brand">Unsupported card brand</string>
+    <string name="error_api_invalid_card_unsupported_brand">Unsupported card brand</string>
+
+    <string name="error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount">Amount exceeds the valid amount of %s</string>
+    <string name="error_api_bad_request_amount_is_greater_than_valid_amount_without_valid_amount">Amount exceeds the valid amount</string>
+    <string name="error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount">Amount is less than the valid amount of %s</string>
+    <string name="error_api_bad_request_amount_is_less_than_valid_amount_without_valid_amount">Amount is less than the valid amoun</string>
+    <string name="error_api_bad_request_currency_not_supported">The currency is not supported by this account</string>
+    <string name="error_api_bad_request_empty_name">The customer name is empty</string>
+    <string name="error_api_bad_request_invalid_currency">The currency is invalid</string>
+    <string name="error_api_bad_request_invalid_email">The customer email is invalid</string>
+    <string name="error_api_bad_request_invalid_name">The customer name is invalid</string>
+    <string name="error_api_bad_request_invalid_phone_number">The customer phone number is invalid</string>
+    <string name="error_api_bad_request_name_is_too_long_with_valid_length">The customer name exceeds the %d character limit</string>
+    <string name="error_api_bad_request_name_is_too_long_without_valid_length">The customer name is too long</string>
+    <string name="error_api_bad_request_type_not_supported">The source type is not supported by this account</string>
+    <string name="error_api_bad_request_other">Bad request: %s</string>
 
     <string name="error_unknown">Unknown error occurred. (%1$s)</string>
     <string name="label_card_name">Name on card</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="error_api_bad_request_type_not_supported">The source type is not supported by this account</string>
     <string name="error_api_bad_request_other">Bad request: %s</string>
 
+    <string name="error_api_service_not_found">Service not found</string>
+
     <string name="error_unknown">Unknown error occurred. (%1$s)</string>
     <string name="label_card_name">Name on card</string>
     <string name="label_card_number">Card number</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -23,10 +23,10 @@
     <string name="error_api_invalid_card_empty_card_holder_name">Invalid card holder name</string>
     <string name="error_api_invalid_card_unsupported_brand">Unsupported card brand</string>
 
-    <string name="error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount">Amount exceeds the valid amount of %s</string>
+    <string name="error_api_bad_request_amount_is_greater_than_valid_amount_with_valid_amount">Amount exceeds the valid amount of %d %s</string>
     <string name="error_api_bad_request_amount_is_greater_than_valid_amount_without_valid_amount">Amount exceeds the valid amount</string>
-    <string name="error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount">Amount is less than the valid amount of %s</string>
-    <string name="error_api_bad_request_amount_is_less_than_valid_amount_without_valid_amount">Amount is less than the valid amoun</string>
+    <string name="error_api_bad_request_amount_is_less_than_valid_amount_with_valid_amount">Amount is less than the valid amount of %d %s</string>
+    <string name="error_api_bad_request_amount_is_less_than_valid_amount_without_valid_amount">Amount is less than the valid amount</string>
     <string name="error_api_bad_request_currency_not_supported">The currency is not supported by this account</string>
     <string name="error_api_bad_request_empty_name">The customer name is empty</string>
     <string name="error_api_bad_request_invalid_currency">The currency is invalid</string>

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -130,9 +130,9 @@ class APIErrorExtensionsTest {
 
         val error = serializer.deserialize(errorResponse.byteInputStream(), APIError::class.java)
         val expectedReasons = listOf(
-                BadRequestReason.AmountIsLessThanValidAmount(150, ""),
-                BadRequestReason.AmountIsLessThanValidAmount(150, ""),
-                BadRequestReason.AmountIsGreaterThanValidAmount(50000, ""),
+                BadRequestReason.AmountIsLessThanValidAmount(150),
+                BadRequestReason.AmountIsLessThanValidAmount(150),
+                BadRequestReason.AmountIsGreaterThanValidAmount(50000),
                 BadRequestReason.InvalidCurrency,
                 BadRequestReason.EmptyName,
                 BadRequestReason.NameIsTooLong(10),

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -80,7 +80,7 @@ class APIErrorExtensionsTest {
 
         val actualMessage = error.getMessageFromResources(resources)
 
-        assertEquals(resources.getString(R.string.error_api_invalid_card_unsopported_brand), actualMessage)
+        assertEquals(resources.getString(R.string.error_api_invalid_card_unsupported_brand), actualMessage)
     }
 
     @Test

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -129,7 +129,13 @@ class APIErrorExtensionsTest {
         """.trimIndent()
 
         val error = serializer.deserialize(errorResponse.byteInputStream(), APIError::class.java)
-
-        assertEquals(APIErrorCode.BadRequest(emptyList()), error.errorCode)
+        val expectedReasons = listOf(
+                BadRequestReason.Unknown("amount must be at least 150"),
+                BadRequestReason.InvalidCurrency,
+                BadRequestReason.EmptyName,
+                BadRequestReason.InvalidEmail,
+                BadRequestReason.InvalidPhoneNumber
+        )
+        assertEquals(APIErrorCode.BadRequest(expectedReasons), error.errorCode)
     }
 }

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -116,4 +116,20 @@ class APIErrorExtensionsTest {
 
         assertEquals(resources.getString(R.string.error_api_authentication_failure), actualMessage)
     }
+
+    @Test
+    fun errorCode_collectDataFromErrorMessage() {
+        val errorResponse = """
+            {
+                "object": "error",
+                "location": "https://www.omise.co/api-errors#bad-request",
+                "code": "bad_request",
+                "message": "amount must be at least 150, currency must be JPY, name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters"
+            }
+        """.trimIndent()
+
+        val error = serializer.deserialize(errorResponse.byteInputStream(), APIError::class.java)
+
+        assertEquals(APIErrorCode.BadRequest(emptyList()), error.errorCode)
+    }
 }

--- a/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
+++ b/sdk/src/test/java/co/omise/android/extensions/APIErrorExtensionsTest.kt
@@ -124,15 +124,18 @@ class APIErrorExtensionsTest {
                 "object": "error",
                 "location": "https://www.omise.co/api-errors#bad-request",
                 "code": "bad_request",
-                "message": "amount must be at least 150, currency must be JPY, name cannot be blank, email is in invalid format, and phone_number must contain 10-11 digit characters"
+                "message": "amount must be at least 150, amount must be greater than 150, amount must be less than 50000, currency must be JPY, name cannot be blank,  name is too long (maximum is 10 characters), email is in invalid format, and phone_number must contain 10-11 digit characters"
             }
         """.trimIndent()
 
         val error = serializer.deserialize(errorResponse.byteInputStream(), APIError::class.java)
         val expectedReasons = listOf(
-                BadRequestReason.Unknown("amount must be at least 150"),
+                BadRequestReason.AmountIsLessThanValidAmount(150, ""),
+                BadRequestReason.AmountIsLessThanValidAmount(150, ""),
+                BadRequestReason.AmountIsGreaterThanValidAmount(50000, ""),
                 BadRequestReason.InvalidCurrency,
                 BadRequestReason.EmptyName,
+                BadRequestReason.NameIsTooLong(10),
                 BadRequestReason.InvalidEmail,
                 BadRequestReason.InvalidPhoneNumber
         )


### PR DESCRIPTION
### Objective

To display error messages from creating source API.

### Description of changes

In this PR mapped error messages from API to messaging resources if error messages not matched, it will use the origin error message. And, displayed the Snackbar with the error message when request failed.

### QA

When a request was failed, it should display the Sankbar with the error message

![Screenshot_1568954018](https://user-images.githubusercontent.com/2638321/65304219-534d2a00-dbaa-11e9-9d24-3e90dabd8c65.png)
