### PR TITLE
Downgrade OkHttp to version 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         multidex_version = '2.0.1'
         appcompat_version = '1.1.0'
         joda_time_version = '2.9.2'
-        okhttp_version = '4.0.1'
+        okhttp_version = '3.12.0'
         material_version = '1.0.0'
         support_annotations_version = '28.0.0'
         guava_version = '19.0'

--- a/sdk/src/main/java/co/omise/android/api/Configurer.kt
+++ b/sdk/src/main/java/co/omise/android/api/Configurer.kt
@@ -32,8 +32,8 @@ class Configurer internal constructor(private val config: Config) : Interceptor 
         @JvmStatic
         internal fun configure(config: Config, request: Request): Request {
             val apiVersion = config.apiVersion()
-            val endpoint = Endpoint.allEndpointsByHost[request.url.host]
-                    ?: throw UnsupportedOperationException("unknown endpoint: " + request.url.host)
+            val endpoint = Endpoint.allEndpointsByHost[request.url().host()]
+                    ?: throw UnsupportedOperationException("unknown endpoint: " + request.url().host())
 
             val key = endpoint.authenticationKey(config)
             var builder = request.newBuilder()

--- a/sdk/src/main/java/co/omise/android/api/Invocation.kt
+++ b/sdk/src/main/java/co/omise/android/api/Invocation.kt
@@ -39,15 +39,15 @@ internal class Invocation<T : Model>(
 
     private fun processCall(call: TypedCall) {
         val response = call.execute()
-        if (response.body == null) {
+        if (response.body() == null) {
             didFail(IOException("HTTP response have no body."))
             return
         }
 
-        val stream = response.body!!.byteStream()
+        val stream = response.body()!!.byteStream()
         when {
-            response.code in 200..299 -> didSucceed(serializer.deserialize(stream, call.clazz))
-            response.code in 300..399 -> didFail(RedirectionException())
+            response.code() in 200..299 -> didSucceed(serializer.deserialize(stream, call.clazz))
+            response.code() in 300..399 -> didFail(RedirectionException())
             else -> didFail(serializer.deserialize(stream, APIError::class.java))
         }
     }

--- a/sdk/src/main/java/co/omise/android/api/RequestBuilder.kt
+++ b/sdk/src/main/java/co/omise/android/api/RequestBuilder.kt
@@ -3,9 +3,8 @@ package co.omise.android.api
 import co.omise.android.models.Model
 import co.omise.android.models.Serializer
 import okhttp3.HttpUrl
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType
 import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.Objects.requireNonNull
@@ -85,7 +84,7 @@ abstract class RequestBuilder<T : Model> {
     protected fun serialize(): RequestBody {
         val stream = ByteArrayOutputStream(4096)
         serializer().serializeRequestBuilder(stream, this)
-        return stream.toByteArray().toRequestBody(JSON_MEDIA_TYPE, 0, stream.size())
+        return RequestBody.create(JSON_MEDIA_TYPE, stream.toByteArray())
     }
 
     private fun serializer(): Serializer {
@@ -107,6 +106,6 @@ abstract class RequestBuilder<T : Model> {
         const val GET = "GET"
         const val PATCH = "PATCH"
         const val DELETE = "DELETE"
-        val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaTypeOrNull()
+        val JSON_MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8")
     }
 }


### PR DESCRIPTION
As team discussed SDK needs to support Android 4.1 (API 16). So, we need to downgraded **OkHttp** to version 3 cause version 4 support Android 5.1 (API 21) above. 

> ### IMPORTANT NOTE 🚨
> However, **OkHttp** version 3 will support until December 31, 2020 https://github.com/square/okhttp#requirements. SDK might needs to upgrade minimum version in the future.