### PR TITLE
Fixed OmiseTheme to support Android 4.1.

### DIFF
--- a/app/src/main/res/layout/activity_checkout.xml
+++ b/app/src/main/res/layout/activity_checkout.xml
@@ -65,14 +65,15 @@
 
         <Button
             android:id="@+id/choose_payment_method_button"
+            style="?android:attr/buttonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/large_margin"
             android:layout_marginLeft="@dimen/large_margin"
+            android:layout_marginTop="@dimen/large_margin"
             android:layout_marginEnd="@dimen/large_margin"
             android:layout_marginRight="@dimen/large_margin"
             android:layout_marginBottom="@dimen/medium_margin"
-            android:layout_marginTop="@dimen/large_margin"
             android:text="@string/button_choose_payment_method"
             app:layout_constraintBottom_toTopOf="@id/credit_card_button"
             app:layout_constraintEnd_toEndOf="parent"
@@ -82,6 +83,7 @@
 
         <Button
             android:id="@+id/credit_card_button"
+            style="?android:attr/buttonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/large_margin"
@@ -96,6 +98,7 @@
 
         <Button
             android:id="@+id/authorize_url_button"
+            style="?android:attr/buttonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/large_margin"

--- a/sdk/src/main/res/drawable-v21/bg_edit_text_outlined.xml
+++ b/sdk/src/main/res/drawable-v21/bg_edit_text_outlined.xml
@@ -6,8 +6,8 @@
                 <shape android:shape="rectangle">
                     <padding android:bottom="@dimen/edit_text_padding" android:left="@dimen/edit_text_padding" android:right="@dimen/edit_text_padding" android:top="@dimen/edit_text_padding" />
                     <size android:height="@dimen/edit_text_height" />
-                    <solid android:color="#00ffffff" />
-                    <stroke android:width="@dimen/edit_text_stroke_width" android:color="#1a56f0" />
+                    <solid android:color="@android:color/transparent" />
+                    <stroke android:width="@dimen/edit_text_stroke_width" android:color="?attr/colorAccent" />
                     <corners android:radius="@dimen/edit_text_radius_size" />
                 </shape>
             </item>
@@ -18,9 +18,9 @@
             <item>
                 <shape android:shape="rectangle">
                     <padding android:bottom="@dimen/edit_text_padding" android:left="@dimen/edit_text_padding" android:right="@dimen/edit_text_padding" android:top="@dimen/edit_text_padding" />
-                    <solid android:color="#00ffffff" />
+                    <solid android:color="@android:color/transparent" />
                     <size android:height="@dimen/edit_text_height" />
-                    <stroke android:width="@dimen/edit_text_stroke_width" android:color="#aaa" />
+                    <stroke android:width="@dimen/edit_text_stroke_width" android:color="@android:color/darker_gray" />
                     <corners android:radius="@dimen/edit_text_radius_size" />
                 </shape>
             </item>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -44,7 +44,7 @@
 
     <style name="OmiseBodyTitle" parent="TextAppearance.AppCompat.Body1" />
 
-    <style name="OmiseButton" parent="Widget.AppCompat.Button">
+    <style name="OmiseButton" parent="Widget.MaterialComponents.Button">
         <item name="android:background">@drawable/bg_button</item>
         <item name="android:textAppearance">@style/OmiseButtonTextAppearance</item>
     </style>


### PR DESCRIPTION
### Objective

Bug fixes using `OmiseTheme` on Android 4.1 cause API lower 21 is not supported refer `@color` in **Drawable** resource.

### Description of Changes

In this PR created separated **Drawable** resource for API 21. And, created `bg_edit_text_outlined.xml` that using code color instead of color reference.

### QA

The sample shall run the app with **OmiseTheme** with no crash on Android 4.1.