### PR TITLE
T20318 - Support zero interest installments in the payment creator

### DIFF
--- a/app/src/main/java/co/omise/android/example/PaymentSetting.kt
+++ b/app/src/main/java/co/omise/android/example/PaymentSetting.kt
@@ -10,6 +10,7 @@ object PaymentSetting {
     @JvmStatic
     fun getPaymentMethodPreferences(context: Context): Map<String, Boolean> =
             listOf(
+                    R.string.payment_preference_zero_interest_installments_key,
                     R.string.payment_preference_credit_card_key,
                     R.string.payment_preference_internet_banking_bay_key,
                     R.string.payment_preference_internet_banking_ktb_key,
@@ -37,7 +38,8 @@ object PaymentSetting {
 
     @JvmStatic
     fun createCapabilityFromPreferences(context: Context): Capability {
-        val sourceTypes = getPaymentMethodPreferences(context)
+        val paymentMethodPreferences = getPaymentMethodPreferences(context)
+        val sourceTypes = paymentMethodPreferences
                 .filter { it.value }
                 .toMap()
                 .map {
@@ -61,9 +63,12 @@ object PaymentSetting {
                 }
                 .filterNotNull()
 
-        val allowCreditCardMethod = getPaymentMethodPreferences(context)
-                .get(context.getString(R.string.payment_preference_credit_card_key)) ?: false
+        val allowCreditCardMethod = paymentMethodPreferences[context.getString(R.string.payment_preference_credit_card_key)]
+                ?: false
 
-        return Capability.create(allowCreditCardMethod, sourceTypes)
+        val zeroInterestInstallments = paymentMethodPreferences[context.getString(R.string.payment_preference_zero_interest_installments_key)]
+                ?: false
+
+        return Capability.create(allowCreditCardMethod, sourceTypes, zeroInterestInstallments)
     }
 }

--- a/app/src/main/java/co/omise/android/example/PaymentSettingFragment.kt
+++ b/app/src/main/java/co/omise/android/example/PaymentSettingFragment.kt
@@ -41,7 +41,7 @@ class PaymentSettingFragment : PreferenceFragmentCompat() {
 
         context?.let {
             PaymentSetting.getPaymentMethodPreferences(it).forEach { preference ->
-                preferenceScreen.findPreference<CheckBoxPreference>(preference.key)?.apply {
+                preferenceScreen.findPreference<Preference>(preference.key)?.apply {
                     this.isEnabled = isUsedSpecificsPaymentMethod
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
 
     <string name="payment_preference_is_use_capability_api_key" translatable="false">is_use_capability_api</string>
     <string name="payment_preference_is_use_specifics_payment_methods_key" translatable="false">is_use_specifics_payment_methods</string>
+    <string name="payment_preference_zero_interest_installments_key" translatable="false">zero_interest_installments</string>
     <string name="payment_preference_credit_card_key" translatable="false">credit_card</string>
     <string name="payment_preference_internet_banking_bay_key" translatable="false">internet_banking_bay</string>
     <string name="payment_preference_internet_banking_ktb_key" translatable="false">internet_banking_ktb</string>
@@ -54,4 +55,8 @@
     <string name="payment_preference_promptpay_title" translatable="false">PromptPay</string>
     <string name="payment_success_but_no_result" translatable="false">Payment success but no result.</string>
     <string name="error_capability_have_not_set_yet" translatable="false">Capability have not set yet.</string>
+    <string name="payment_preference_zero_interest_installments_title" translatable="false">Zero interest installments</string>
+    <string name="payment_preference_zero_interest_installments_summary" translatable="false">Whether merchant absorbs the interest for installment payments</string>
+    <string name="payment_preference_zero_interest_installments_switch_title" translatable="false">Enabled</string>
+
 </resources>

--- a/app/src/main/res/xml/preference_payment_setting.xml
+++ b/app/src/main/res/xml/preference_payment_setting.xml
@@ -93,4 +93,19 @@
             app:title="@string/payment_preference_promptpay_title" />
     </PreferenceCategory>
 
+    <PreferenceCategory
+        app:singleLineTitle="false"
+        app:title="@string/payment_preference_zero_interest_installments_title">
+
+        <Preference
+            app:persistent="false"
+            app:selectable="false"
+            app:summary="@string/payment_preference_zero_interest_installments_summary" />
+
+        <SwitchPreference
+            app:defaultValue="true"
+            app:key="@string/payment_preference_zero_interest_installments_key"
+            app:title="@string/payment_preference_zero_interest_installments_switch_title" />
+    </PreferenceCategory>
+
 </androidx.preference.PreferenceScreen>

--- a/sdk/src/main/java/co/omise/android/models/Capability.kt
+++ b/sdk/src/main/java/co/omise/android/models/Capability.kt
@@ -44,7 +44,7 @@ data class Capability(
          * The helper function for creating an instance of the [Capability] class.
          *
          * @param allowCreditCard allow to create a [Token] with a credit card or not. Default is true.
-         * @param sourceTypes list of [SourceType] that allow to create a [Source].\
+         * @param sourceTypes list of [SourceType] that allow to create a [Source].
          * @param zeroInterestInstallments whether merchant absorbs interest for installment payments.
          *
          * @return an instance of [Capability] with specific configuration.

--- a/sdk/src/main/java/co/omise/android/models/Capability.kt
+++ b/sdk/src/main/java/co/omise/android/models/Capability.kt
@@ -42,12 +42,15 @@ data class Capability(
 
         /**
          * The helper function for creating an instance of the [Capability] class.
+         *
          * @param allowCreditCard allow to create a [Token] with a credit card or not. Default is true.
-         * @param sourceTypes list of [SourceType] that allow to create a [Source].
+         * @param sourceTypes list of [SourceType] that allow to create a [Source].\
+         * @param zeroInterestInstallments whether merchant absorbs interest for installment payments.
+         *
          * @return an instance of [Capability] with specific configuration.
          */
         @JvmStatic
-        fun create(allowCreditCard: Boolean = true, sourceTypes: List<SourceType>): Capability {
+        fun create(allowCreditCard: Boolean = true, sourceTypes: List<SourceType>, zeroInterestInstallments: Boolean = false): Capability {
             val paymentMethods = mutableListOf<PaymentMethod>()
 
             if (allowCreditCard) {
@@ -56,7 +59,10 @@ data class Capability(
 
             paymentMethods.addAll(sourceTypes.map(::createSourceTypeMethod))
 
-            return Capability(paymentMethods = paymentMethods)
+            return Capability(
+                    paymentMethods = paymentMethods,
+                    zeroInterestInstallments = zeroInterestInstallments
+            )
         }
     }
 }

--- a/sdk/src/main/java/co/omise/android/models/Source.kt
+++ b/sdk/src/main/java/co/omise/android/models/Source.kt
@@ -145,7 +145,7 @@ data class Source(
             return this
         }
 
-        fun zeroInterestInstallments(zeroInterestInstallments: Boolean?): CreateSourceRequestBuilder {
+        fun zeroInterestInstallments(zeroInterestInstallments: Boolean): CreateSourceRequestBuilder {
             this.zeroInterestInstallments = zeroInterestInstallments
             return this
         }

--- a/sdk/src/main/java/co/omise/android/models/Source.kt
+++ b/sdk/src/main/java/co/omise/android/models/Source.kt
@@ -145,7 +145,7 @@ data class Source(
             return this
         }
 
-        fun zeroInterestInstallments(zeroInterestInstallments: Boolean): CreateSourceRequestBuilder {
+        fun zeroInterestInstallments(zeroInterestInstallments: Boolean?): CreateSourceRequestBuilder {
             this.zeroInterestInstallments = zeroInterestInstallments
             return this
         }

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -64,6 +64,7 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
         view?.let { setAllViewsEnabled(it, false) }
         val request = Source.CreateSourceRequestBuilder(req.amount, req.currency, sourceType)
                 .installmentTerm(item.installmentTerm)
+                .zeroInterestInstallments(req.capability.zeroInterestInstallments)
                 .build()
         requester?.request(request) {
             view?.let { setAllViewsEnabled(it, true) }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -32,7 +32,7 @@ class PaymentCreatorActivity : OmiseActivity() {
     private val client: Client by lazy { Client(pkey) }
 
     private val requester: PaymentCreatorRequester<Source> by lazy {
-        PaymentCreatorRequesterImpl(client, amount, currency)
+        PaymentCreatorRequesterImpl(client, amount, currency, capability)
     }
 
     @VisibleForTesting
@@ -197,6 +197,7 @@ private class PaymentCreatorNavigationImpl(
 interface PaymentCreatorRequester<T : Model> {
     val amount: Long
     val currency: String
+    val capability: Capability
     fun request(request: Request<T>, result: ((Result<T>) -> Unit)? = null)
     var listener: PaymentCreatorRequestListener?
 }
@@ -208,7 +209,8 @@ interface PaymentCreatorRequestListener {
 private class PaymentCreatorRequesterImpl(
         private val client: Client,
         override val amount: Long,
-        override val currency: String
+        override val currency: String,
+        override val capability: Capability
 ) : PaymentCreatorRequester<Source> {
 
     override var listener: PaymentCreatorRequestListener? = null

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentTermChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentTermChooserFragmentTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.R
+import co.omise.android.models.Capability
 import co.omise.android.models.PaymentMethod
 import co.omise.android.models.Source
 import co.omise.android.utils.itemCount
@@ -32,6 +33,7 @@ class InstallmentTermChooserFragmentTest {
     private val mockRequester: PaymentCreatorRequester<Source> = mock {
         on { amount }.doReturn(500000L)
         on { currency }.doReturn("thb")
+        on { capability }.doReturn(Capability.create(sourceTypes = emptyList()))
     }
 
     private val fragment = InstallmentTermChooserFragment.newInstance(paymentMethod).apply {


### PR DESCRIPTION
**1. Objective**

To able the payment creator accepts the `zeroInterestInstallments` parameter if it present in the `Capability` object.

**2. Description of change**

In the `InstallmentTermChooserFragment`, correct the `zeroInterestInstallments` parameter from the `Capability` object and set it into the source request. 

Also, added `zeroInterestInstallments` setting into the payment settings in the sample app. 

![Screenshot_1586249925](https://user-images.githubusercontent.com/2638321/78652279-b8b8fc00-78eb-11ea-873e-4f5969f54880.png)

**3. Quality assurance**

When create a source via the payment creator, the payment creator should return a source response that contains `zeroInterestInstallments` value same in the request.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal