### PR TITLE
T20531 - Fix creating source

### DIFF
--- a/sdk/src/main/java/co/omise/android/models/Serializer.kt
+++ b/sdk/src/main/java/co/omise/android/models/Serializer.kt
@@ -63,6 +63,7 @@ class Serializer {
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true)
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
     }
 
     /**

--- a/sdk/src/main/java/co/omise/android/models/Source.kt
+++ b/sdk/src/main/java/co/omise/android/models/Source.kt
@@ -79,7 +79,7 @@ data class Source(
         @JsonProperty("phone_number")
         private var phoneNumber: String? = null
         @JsonProperty("installment_term")
-        private var installmentTerm: Int = 0
+        private var installmentTerm: Int? = null
         @JsonProperty("zero_interest_installments")
         private var zeroInterestInstallments: Boolean? = null
 

--- a/sdk/src/main/java/co/omise/android/models/Source.kt
+++ b/sdk/src/main/java/co/omise/android/models/Source.kt
@@ -38,7 +38,7 @@ data class Source(
         @field:JsonProperty("mobile_number")
         val mobileNumber: String? = null,
         @field:JsonProperty("installment_term")
-        val installmentTerm: Int = 0,
+        val installmentTerm: Int? = null,
         @field:JsonProperty("scannable_code")
         val scannableCode: Barcode? = null,
         @field:JsonProperty("zero_interest_installments")

--- a/sdk/src/test/java/co/omise/android/SerializationTest.java
+++ b/sdk/src/test/java/co/omise/android/SerializationTest.java
@@ -44,7 +44,7 @@ public class SerializationTest extends OmiseTest {
         }
 
         for (Map.Entry<String, Object> entry : differences.entriesOnlyOnLeft().entrySet()) {
-            if (entry.getKey().equals("deleted")) {
+            if (entry.getKey().equals("deleted") || entry.getValue() == null) {
                 continue;
             }
 


### PR DESCRIPTION
**1. Objective**

To fix creating source received a response that contains unrelated the parameters.

**2. Description of change**

In this PR rid of default value from the create source parameters to prevent create a source with default field values.

**3. Quality assurance**

When create a new source, the response shouldn't contains fields that unrelated to the parameters.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal