### PR TITLE
Enable WebView's local storage

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -3,7 +3,10 @@ package co.omise.android.ui
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.webkit.CookieManager
+import android.webkit.CookieSyncManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
@@ -27,7 +30,8 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_authorizing_payment)
-        webView.settings.javaScriptEnabled = true
+
+        initializeWebView()
 
         supportActionBar?.setTitle(R.string.title_authorizing_payment)
 
@@ -73,5 +77,36 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         setResult(RESULT_CANCELED)
         super.onBackPressed()
     }
-}
 
+    override fun onDestroy() {
+        clearCache()
+        super.onDestroy()
+    }
+
+    private fun initializeWebView() {
+        with(webView.settings) {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            databaseEnabled = true
+        }
+    }
+
+    private fun clearCache() {
+        webView.clearCache(true)
+        webView.clearHistory()
+
+        val cookieManager = CookieManager.getInstance()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            cookieManager.removeAllCookies(null)
+            cookieManager.flush()
+        } else {
+            val cookieSyncManager = CookieSyncManager.createInstance(this)
+            cookieManager.removeAllCookie()
+            cookieManager.removeSessionCookie()
+            cookieSyncManager.startSync()
+            cookieSyncManager.stopSync()
+            cookieSyncManager.sync()
+        }
+    }
+}


### PR DESCRIPTION
**1. Objective**

In this PR purpose to enable local storage to support the authorize URI that required to use local cache on the WebView. However, the local cache life time will limit only while authorizing URI flow. After completed authorize URI the WebView will clear all cache.

Reference: https://developer.android.com/training/articles/security-tips#WebView

**2. Description of change**

Enabled cache on the WebView in the **AuthorizingPaymentActivity**.  And clean cache after the Activity was destroyed.

**3. Quality assurance**

The authorize URI that required to use local cache shall be able to proceed.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

High