### PR TITLE
Initialize 3DS SDK

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -11,6 +11,8 @@ import co.omise.android.AuthorizingPaymentURLVerifier
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.EXTRA_RETURNED_URLSTRING
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.REQUEST_EXTERNAL_CODE
 import co.omise.android.R
+import co.omise.android.threeds.ThreeDS
+import co.omise.android.threeds.ThreeDSAuthorizingTransactionListener
 import kotlinx.android.synthetic.main.activity_authorizing_payment.*
 
 /**
@@ -19,10 +21,11 @@ import kotlinx.android.synthetic.main.activity_authorizing_payment.*
  * In case the authorization needs to be handled by an external app, the SDK opens that external
  * app by default but the Intent callback needs to be handled by the implementer.
  */
-class AuthorizingPaymentActivity : AppCompatActivity() {
+class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSAuthorizingTransactionListener {
 
     private val webView: WebView by lazy { authorizing_payment_webview }
     private lateinit var verifier: AuthorizingPaymentURLVerifier
+    private lateinit var threeDS: ThreeDS
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,10 +35,18 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         supportActionBar?.setTitle(R.string.title_authorizing_payment)
 
         verifier = AuthorizingPaymentURLVerifier(intent)
+        threeDS = ThreeDS(this).apply {
+            setAuthorizingTransactionListener(this@AuthorizingPaymentActivity)
+        }
+
         if (verifier.isReady) {
             webView.loadUrl(verifier.authorizedURLString)
         }
 
+        setupWebViewClient()
+    }
+
+    private fun setupWebViewClient() {
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
                 val uri = Uri.parse(url)
@@ -72,6 +83,18 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     override fun onBackPressed() {
         setResult(RESULT_CANCELED)
         super.onBackPressed()
+    }
+
+    override fun onCompleted() {
+        TODO("Not yet implemented")
+    }
+
+    override fun onUnsupported() {
+        TODO("Fallback to 3DS V1 redirect flow")
+    }
+
+    override fun onError(e: Throwable) {
+        TODO("Not yet implemented")
     }
 }
 

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -37,6 +37,7 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSAuthorizingTransa
         verifier = AuthorizingPaymentURLVerifier(intent)
         threeDS = ThreeDS(this).apply {
             setAuthorizingTransactionListener(this@AuthorizingPaymentActivity)
+            authorizeTransaction(verifier.authorizedURLString)
         }
 
         if (verifier.isReady) {

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -81,6 +81,12 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSAuthorizingTransa
         }
     }
 
+    override fun onDestroy() {
+        threeDS.cleanup()
+
+        super.onDestroy()
+    }
+
     override fun onBackPressed() {
         setResult(RESULT_CANCELED)
         super.onBackPressed()

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -24,8 +24,12 @@ import kotlinx.android.synthetic.main.activity_authorizing_payment.*
 class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSAuthorizingTransactionListener {
 
     private val webView: WebView by lazy { authorizing_payment_webview }
-    private lateinit var verifier: AuthorizingPaymentURLVerifier
-    private lateinit var threeDS: ThreeDS
+    private val verifier: AuthorizingPaymentURLVerifier by lazy { AuthorizingPaymentURLVerifier(intent) }
+    private val threeDS: ThreeDS by lazy {
+        ThreeDS(this).apply {
+            setAuthorizingTransactionListener(this@AuthorizingPaymentActivity)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,17 +38,10 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSAuthorizingTransa
 
         supportActionBar?.setTitle(R.string.title_authorizing_payment)
 
-        verifier = AuthorizingPaymentURLVerifier(intent)
-        threeDS = ThreeDS(this).apply {
-            setAuthorizingTransactionListener(this@AuthorizingPaymentActivity)
-            authorizeTransaction(verifier.authorizedURLString)
-        }
-
-        if (verifier.isReady) {
-            webView.loadUrl(verifier.authorizedURLString)
-        }
-
         setupWebViewClient()
+        loadAuthorizeUrl()
+
+        threeDS.authorizeTransaction(verifier.authorizedURLString)
     }
 
     private fun setupWebViewClient() {
@@ -70,6 +67,12 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSAuthorizingTransa
                     false
                 }
             }
+        }
+    }
+
+    private fun loadAuthorizeUrl() {
+        if (verifier.isReady) {
+            webView.loadUrl(verifier.authorizedURLString)
         }
     }
 


### PR DESCRIPTION
## Purpose

To initialize the 3DS SDK in the `AuthorizingPaymentActivity` class. 

## Description

In this PR add thee `ThreeDS` to the `AuthorizingPaymentActivity` properties. And implemented `ThreeDSAuthorizingTransactionListener` for listening result from the `ThreeDS`.

## Quality assurance

N/A

## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A