### PR TITLE
Observe token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         target_sdk_version = 28
 
         kotlin_version = '1.3.50'
-        android_plugin_version = '3.5.1'
+        android_plugin_version = '4.0.1'
         multidex_version = '2.0.1'
         appcompat_version = '1.1.0'
         joda_time_version = '2.9.2'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ buildscript {
         mockito_version = '3.0.0'
         mockito_kotlin_version = '2.2.0'
         constraintlayout_version = '1.1.3'
+        coroutines_version = '1.3.9'
+        lifecycle_version = '2.2.0'
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,4 @@
 # org.gradle.parallel=true
 
 android.enableJetifier=true
-android.enableUnitTestBinaryResources=true
 android.useAndroidX=true

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -124,6 +124,11 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:$joda_time_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     debugImplementation("androidx.fragment:fragment-testing:$fragment_testing_version") {
         exclude group: 'androidx.test', module: 'core'

--- a/sdk/src/main/java/co/omise/android/api/Client.kt
+++ b/sdk/src/main/java/co/omise/android/api/Client.kt
@@ -24,6 +24,7 @@ class Client(publicKey: String) {
 
     private var httpClient: OkHttpClient
     private val background: Executor
+    private val handler = Handler()
 
     init {
         background = Executors.newSingleThreadExecutor()
@@ -38,7 +39,6 @@ class Client(publicKey: String) {
      * @param listener The [RequestListener] to listen for request response.
      */
     fun <T : Model> send(request: Request<T>, listener: RequestListener<T>) {
-        val handler = Handler()
         background.execute { Invocation(handler, httpClient, request, listener).invoke() }
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -146,7 +146,7 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
     }
 
     override fun onAuthenticated() {
-        viewModel.startPollingToken(tokenID)
+        viewModel.observeTokenChange(tokenID)
     }
 
     override fun onUnsupported() {

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -4,10 +4,8 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.webkit.CookieManager
-import android.webkit.CookieSyncManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
@@ -20,7 +18,7 @@ import co.omise.android.R
 import co.omise.android.threeds.ThreeDS
 import co.omise.android.threeds.ThreeDSListener
 import co.omise.android.threeds.ui.ProgressView
-import kotlinx.android.synthetic.main.activity_authorizing_payment.*
+import kotlinx.android.synthetic.main.activity_authorizing_payment.authorizing_payment_webview
 
 /**
  * AuthorizingPaymentActivity is an experimental helper UI class in the SDK that would help
@@ -172,17 +170,7 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
         webView.clearHistory()
 
         val cookieManager = CookieManager.getInstance()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            cookieManager.removeAllCookies(null)
-            cookieManager.flush()
-        } else {
-            val cookieSyncManager = CookieSyncManager.createInstance(this)
-            cookieManager.removeAllCookie()
-            cookieManager.removeSessionCookie()
-            cookieSyncManager.startSync()
-            cookieSyncManager.stopSync()
-            cookieSyncManager.sync()
-        }
+        cookieManager.removeAllCookies(null)
+        cookieManager.flush()
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -131,6 +131,7 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
         clearCache()
         handler.removeCallbacks(runnable)
         threeDS.cleanup()
+        viewModel.cleanup()
 
         super.onDestroy()
     }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -12,6 +12,7 @@ import android.webkit.CookieSyncManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import co.omise.android.AuthorizingPaymentURLVerifier
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.EXTRA_RETURNED_URLSTRING
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.REQUEST_EXTERNAL_CODE
@@ -46,6 +47,8 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
     private var runnable: Runnable? = null
     private val delay = 3_000L
 
+    private lateinit var viewModel: AuthorizingPaymentViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_authorizing_payment)
@@ -57,6 +60,9 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
             throw IllegalAccessException("Can not found ${OmiseActivity.Companion::EXTRA_TOKEN.name}.")
         }
 
+        val omisePublicKey = intent.getStringExtra(OmiseActivity.EXTRA_PKEY)
+        viewModel = ViewModelProvider(this, AuthorizingPaymentViewModelFactory(omisePublicKey)).get(AuthorizingPaymentViewModel::class.java)
+
         initializeWebView()
 
         supportActionBar?.setTitle(R.string.title_authorizing_payment)
@@ -66,7 +72,8 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
 //        progressDialog.show()
 //        threeDS.authorizeTransaction(verifier.authorizedURLString)
 
-        retrieveToken()
+        val tokenID = intent.getStringExtra(OmiseActivity.EXTRA_TOKEN)
+        viewModel.pollingToken(tokenID)
     }
 
     private fun setupWebViewClient() {

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -106,8 +106,10 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
     }
 
     private fun loadAuthorizeUrl() {
-        if (verifier.isReady) {
-            webView.loadUrl(verifier.authorizedURLString)
+        runOnUiThread {
+            if (verifier.isReady) {
+                webView.loadUrl(verifier.authorizedURLString)
+            }
         }
     }
 
@@ -120,7 +122,8 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
     private fun authorizeFailed(error: Throwable? = null) {
         progressDialog.dismiss()
         val errorIntent = Intent().apply {
-            putExtra(OmiseActivity.EXTRA_ERROR, error)
+            // TODO: Send appropriate error
+            putExtra(OmiseActivity.EXTRA_ERROR, error?.message)
         }
         setResult(Activity.RESULT_CANCELED, errorIntent)
         finish()

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -12,6 +12,7 @@ import android.webkit.CookieSyncManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import co.omise.android.AuthorizingPaymentURLVerifier
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.EXTRA_RETURNED_URLSTRING
@@ -73,7 +74,14 @@ class AuthorizingPaymentActivity : AppCompatActivity(), ThreeDSListener {
 //        threeDS.authorizeTransaction(verifier.authorizedURLString)
 
         val tokenID = intent.getStringExtra(OmiseActivity.EXTRA_TOKEN)
-        viewModel.pollingToken(tokenID)
+        viewModel.startPollingToken(tokenID)
+        viewModel.authorizingPaymentResult.observe(this, Observer { result ->
+            if (result.isSuccess) {
+                val token = result.getOrNull()
+            } else {
+                val error = result.exceptionOrNull()
+            }
+        })
     }
 
     private fun setupWebViewClient() {

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -1,5 +1,6 @@
 package co.omise.android.ui
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -12,6 +13,7 @@ import co.omise.android.models.ChargeStatus
 import co.omise.android.models.Model
 import co.omise.android.models.Token
 import co.omise.android.threeds.core.SDKCoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.coroutines.resume
@@ -37,6 +39,7 @@ internal class AuthorizingPaymentViewModel(private val client: Client) : ViewMod
     fun pollingToken(tokenID: String) = scope.launch {
         try {
             val token = sendGetTokenRequest(tokenID)
+            Log.d("polling token", token.chargeStatus.value)
             when (token.chargeStatus) {
                 ChargeStatus.Successful -> _authorizingPaymentResult.postValue(Result.success(token))
 
@@ -73,5 +76,9 @@ internal class AuthorizingPaymentViewModel(private val client: Client) : ViewMod
         delay(requestDelay)
 
         pollingToken(tokenID)
+    }
+
+    fun cleanup() {
+        scope.cancel()
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import co.omise.android.api.Client
+import co.omise.android.models.APIError
 import co.omise.android.models.ChargeStatus
 import co.omise.android.models.Token
 import co.omise.android.threeds.core.SDKCoroutineScope
@@ -56,6 +57,13 @@ internal class AuthorizingPaymentViewModel(private val client: Client) : ViewMod
                     delay(requestDelay)
                     observeChargeStatus(tokenID)
                 }
+            }
+        } catch (e: APIError) {
+            if (e.code == "search_unavailable") {
+                delay(requestDelay)
+                observeChargeStatus(tokenID)
+            } else {
+                _authorizingPaymentResult.postValue(Result.failure(e))
             }
         } catch (e: Throwable) {
             _authorizingPaymentResult.postValue(Result.failure(e))

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -1,0 +1,77 @@
+package co.omise.android.ui
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import co.omise.android.api.Client
+import co.omise.android.api.Request
+import co.omise.android.api.RequestListener
+import co.omise.android.models.APIError
+import co.omise.android.models.ChargeStatus
+import co.omise.android.models.Model
+import co.omise.android.models.Token
+import co.omise.android.threeds.core.SDKCoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+
+internal class AuthorizingPaymentViewModelFactory(private val omisePublicKey: String) : ViewModelProvider.Factory {
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        return AuthorizingPaymentViewModel(Client(omisePublicKey)) as T
+    }
+}
+
+internal class AuthorizingPaymentViewModel(private val client: Client) : ViewModel() {
+
+    private val maxTimeout = 30_000L // 30 secs
+    private val requestDelay = 3_000L // 3 secs
+    private val scope = SDKCoroutineScope().coroutineScope
+
+    private val _authorizingPaymentResult = MutableLiveData<Result<Token>>()
+    val authorizingPaymentResult: LiveData<Result<Token>> = _authorizingPaymentResult
+
+    fun pollingToken(tokenID: String) = scope.launch {
+        try {
+            val token = sendGetTokenRequest(tokenID)
+            when (token.chargeStatus) {
+                ChargeStatus.Successful -> _authorizingPaymentResult.postValue(Result.success(token))
+
+                ChargeStatus.Reversed,
+                ChargeStatus.Expired,
+                ChargeStatus.Failed -> TODO()
+
+                ChargeStatus.Unknown,
+                ChargeStatus.Pending -> recurRetrieveToken(tokenID)
+            }
+        } catch (e: APIError) {
+           e.printStackTrace()
+        } catch (e: Throwable) {
+            e.printStackTrace()
+        }
+    }
+
+    private suspend fun sendGetTokenRequest(tokenID: String) =
+            sendRequest(Token.GetTokenRequestBuilder(tokenID).build())
+
+    private suspend fun <T : Model> sendRequest(request: Request<T>) = suspendCoroutine<T> { continuation ->
+        client.send(request, object : RequestListener<T> {
+            override fun onRequestSucceed(model: T) {
+                continuation.resume(model)
+            }
+
+            override fun onRequestFailed(throwable: Throwable) {
+                continuation.resumeWithException(throwable)
+            }
+        })
+    }
+
+    private suspend fun recurRetrieveToken(tokenID: String) {
+        delay(requestDelay)
+
+        pollingToken(tokenID)
+    }
+}

--- a/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
@@ -19,6 +19,7 @@ abstract class OmiseActivity : AppCompatActivity() {
         const val EXTRA_TOKEN = "OmiseActivity.token"
         const val EXTRA_TOKEN_OBJECT = "OmiseActivity.tokenObject"
         const val EXTRA_CARD_OBJECT = "OmiseActivity.cardObject"
+        const val EXTRA_ERROR = "OmiseActivity.error"
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Purpose

After the 3DS SDK returned the result and the result is authenticated, the SDK should observe the charge's status from the Token API until the change status updated or timed out.

## Description

When the 3DS SDK invokes `onAuthenticated()`, the SDK will observe the charge's status from by sending request to Token API to get the latest status. If the charge's status is `pending` or `unknown`, the SDK will interval every 3 seconds until the charge's status changed. The SDK will return the timeout error if exceeds 30 seconds.

## Quality assurance

N/A

## Operations impact

There are 2 new parameters that required from the requestor app.
- `EXTRA_TOKEN` the token ID.
- `EXTRA_PKEY` the public key.

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A