### PR TITLE
Add installment SCB support

### DIFF
--- a/app/src/main/java/co/omise/android/example/PaymentSetting.kt
+++ b/app/src/main/java/co/omise/android/example/PaymentSetting.kt
@@ -23,6 +23,7 @@ object PaymentSetting {
                     R.string.payment_preference_installment_bbl_key,
                     R.string.payment_preference_installment_ktc_key,
                     R.string.payment_preference_installment_kbank_key,
+                    R.string.payment_preference_installment_scb_key,
                     R.string.payment_preference_econtext_key,
                     R.string.payment_preference_paynow_key,
                     R.string.payment_preference_promptpay_key,
@@ -57,6 +58,7 @@ object PaymentSetting {
                         context.getString(R.string.payment_preference_installment_bbl_key) -> SourceType.Installment.Bbl
                         context.getString(R.string.payment_preference_installment_ktc_key) -> SourceType.Installment.Ktc
                         context.getString(R.string.payment_preference_installment_kbank_key) -> SourceType.Installment.KBank
+                        context.getString(R.string.payment_preference_installment_scb_key) -> SourceType.Installment.Scb
                         context.getString(R.string.payment_preference_econtext_key) -> SourceType.Econtext
                         context.getString(R.string.payment_preference_paynow_key) -> SourceType.PayNow
                         context.getString(R.string.payment_preference_promptpay_key) -> SourceType.PromptPay

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="payment_preference_installment_bbl_key" translatable="false">installment_bbl</string>
     <string name="payment_preference_installment_ktc_key" translatable="false">installment_ktc</string>
     <string name="payment_preference_installment_kbank_key" translatable="false">installment_kbank</string>
+    <string name="payment_preference_installment_scb_key" translatable="false">installment_scb</string>
     <string name="payment_preference_econtext_key" translatable="false">econtext</string>
     <string name="payment_preference_paynow_key" translatable="false">paynow</string>
     <string name="payment_preference_promptpay_key" translatable="false">promptpay</string>
@@ -52,6 +53,7 @@
     <string name="payment_preference_installment_bbl_title" translatable="false">BBL - Installment</string>
     <string name="payment_preference_installment_ktc_title" translatable="false">KTC - Installment</string>
     <string name="payment_preference_installment_kbank_title" translatable="false">Kasikorn - Installment</string>
+    <string name="payment_preference_installment_scb_title" translatable="false">Siam Commercial - Installment</string>
     <string name="payment_preference_econtext_title" translatable="false">econtext</string>
     <string name="payment_preference_paynow_title" translatable="false">PayNow</string>
     <string name="payment_preference_promptpay_title" translatable="false">PromptPay</string>

--- a/app/src/main/res/xml/preference_payment_setting.xml
+++ b/app/src/main/res/xml/preference_payment_setting.xml
@@ -79,6 +79,11 @@
 
         <CheckBoxPreference
             app:defaultValue="true"
+            app:key="@string/payment_preference_installment_scb_key"
+            app:title="@string/payment_preference_installment_scb_title" />
+
+        <CheckBoxPreference
+            app:defaultValue="true"
             app:key="@string/payment_preference_econtext_key"
             app:title="@string/payment_preference_econtext_title" />
 

--- a/sdk/src/main/java/co/omise/android/models/SourceType.kt
+++ b/sdk/src/main/java/co/omise/android/models/SourceType.kt
@@ -40,6 +40,7 @@ sealed class SourceType(
         object Bbl : Installment("installment_bbl")
         object Ktc : Installment("installment_ktc")
         object KBank : Installment("installment_kbank")
+        object Scb : Installment("installment_scb")
         data class Unknown(@JsonValue override val name: String?) : Installment(name)
 
         companion object {
@@ -50,6 +51,7 @@ sealed class SourceType(
                         Bbl -> listOf(4, 6, 8, 9, 10)
                         Ktc -> listOf(3, 4, 5, 6, 7, 8, 9, 10)
                         KBank -> listOf(3, 4, 6, 10)
+                        Scb -> listOf(3, 4, 6, 9, 10)
                         is Unknown -> emptyList()
                     }
         }
@@ -74,6 +76,7 @@ sealed class SourceType(
             "installment_bbl" -> Installment.Bbl
             "installment_ktc" -> Installment.Ktc
             "installment_kbank" -> Installment.KBank
+            "installment_scb" -> Installment.Scb
             "points_citi" -> PointsCiti
             "paynow" -> PayNow
             "promptpay" -> PromptPay
@@ -108,6 +111,7 @@ val SourceType.Companion.allElements: List<SourceType>
             SourceType.Installment.Bbl,
             SourceType.Installment.Ktc,
             SourceType.Installment.KBank,
+            SourceType.Installment.Scb,
             SourceType.PointsCiti
     )
 

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentChooserFragment.kt
@@ -41,6 +41,7 @@ internal class InstallmentChooserFragment : OmiseListFragment<InstallmentChooser
                 SourceType.Installment.FirstChoice -> InstallmentChooserItem.FirstChoice
                 SourceType.Installment.Bbl -> InstallmentChooserItem.Bbl
                 SourceType.Installment.Ktc -> InstallmentChooserItem.Ktc
+                SourceType.Installment.Scb -> InstallmentChooserItem.Scb
                 is SourceType.Installment.Unknown -> InstallmentChooserItem.Unknown(it.name.orEmpty())
             }
         }
@@ -53,6 +54,7 @@ internal class InstallmentChooserFragment : OmiseListFragment<InstallmentChooser
             InstallmentChooserItem.Bay -> SourceType.Installment.Bay
             InstallmentChooserItem.FirstChoice -> SourceType.Installment.FirstChoice
             InstallmentChooserItem.Ktc -> SourceType.Installment.Ktc
+            InstallmentChooserItem.Scb -> SourceType.Installment.Scb
             is InstallmentChooserItem.Unknown -> SourceType.Installment.Unknown(item.bankName)
         }
         val choseInstallment = paymentMethods.first { (it.backendType as BackendType.Source).sourceType == sourceType }
@@ -105,6 +107,12 @@ internal sealed class InstallmentChooserItem(
     object Ktc : InstallmentChooserItem(
             iconRes = R.drawable.payment_ktc,
             titleRes = R.string.payment_method_installment_ktc_title,
+            indicatorIconRes = R.drawable.ic_next
+    )
+
+    object Scb : InstallmentChooserItem(
+            iconRes = R.drawable.payment_scb,
+            titleRes = R.string.payment_method_installment_scb_title,
             indicatorIconRes = R.drawable.ic_next
     )
 

--- a/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/InstallmentTermChooserFragment.kt
@@ -30,6 +30,7 @@ internal class InstallmentTermChooserFragment : OmiseListFragment<InstallmentTer
             SourceType.Installment.Bbl -> InstallmentChooserItem.Bbl
             SourceType.Installment.Ktc -> InstallmentChooserItem.Ktc
             SourceType.Installment.KBank -> InstallmentChooserItem.KBank
+            SourceType.Installment.Scb -> InstallmentChooserItem.Scb
             is SourceType.Installment.Unknown -> InstallmentChooserItem.Unknown(sourceType.name.orEmpty())
         }.run {
             titleRes?.let { getString(it) } ?: title

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -67,6 +67,7 @@
     <string name="payment_method_installment_first_choice_title">クルンシィ・ファーストチョイス</string>
     <string name="payment_method_installment_kasikorn_title">カシコン</string>
     <string name="payment_method_installment_ktc_title">クルンタイカード</string>
+    <string name="payment_method_installment_scb_title">サイアム・コマーシャル銀行</string>
     <string name="payment_method_installments_title">分割払い</string>
     <string name="payment_method_internet_banking_bay_title">アユタヤ銀行</string>
     <string name="payment_method_internet_banking_bbl_title">バンコク銀行</string>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -67,6 +67,7 @@
     <string name="payment_method_installment_first_choice_title">กรุงศรีเฟิร์สช้อยส์</string>
     <string name="payment_method_installment_kasikorn_title">ธนาคารกสิกรไทย</string>
     <string name="payment_method_installment_ktc_title">เคทีซี</string>
+    <string name="payment_method_installment_scb_title">ธนาคารไทยพาณิชย์</string>
     <string name="payment_method_installments_title">ผ่อนชำระ</string>
     <string name="payment_method_internet_banking_bay_title">ธนาคารกรุงศรีอยุธยา</string>
     <string name="payment_method_internet_banking_bbl_title">ธนาคารกรุงเทพ</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="payment_method_installment_bay_title">Krungsri</string>
     <string name="payment_method_installment_first_choice_title">Krungsri First Choice</string>
     <string name="payment_method_installment_ktc_title">KTC</string>
+    <string name="payment_method_installment_scb_title">Siam Commercial Bank</string>
     <string name="payment_method_installment_term_month_title">%d month</string>
     <string name="payment_method_installment_term_months_title">%d months</string>
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InstallmentChooserFragmentTest.kt
@@ -23,7 +23,8 @@ class InstallmentChooserFragmentTest {
             PaymentMethod(name = "installment_bbl"),
             PaymentMethod(name = "installment_first_choice"),
             PaymentMethod(name = "installment_kbank"),
-            PaymentMethod(name = "installment_ktc")
+            PaymentMethod(name = "installment_ktc"),
+            PaymentMethod(name = "installment_scb")
     )
     private val mockNavigation: PaymentCreatorNavigation = mock()
     private val fragment = InstallmentChooserFragment.newInstance(paymentMethods).apply {

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -55,6 +55,7 @@ class PaymentChooserFragmentTest {
                 PaymentMethod(name = "installment_first_choice"),
                 PaymentMethod(name = "installment_kbank"),
                 PaymentMethod(name = "installment_ktc"),
+                PaymentMethod(name = "installment_scb"),
                 PaymentMethod(name = "internet_banking_bay"),
                 PaymentMethod(name = "internet_banking_bbl"),
                 PaymentMethod(name = "internet_banking_ktb"),
@@ -133,7 +134,8 @@ class PaymentChooserFragmentTest {
                 PaymentMethod(name = "installment_bbl"),
                 PaymentMethod(name = "installment_first_choice"),
                 PaymentMethod(name = "installment_kbank"),
-                PaymentMethod(name = "installment_ktc")
+                PaymentMethod(name = "installment_ktc"),
+                PaymentMethod(name = "installment_scb")
         )
         verify(fragment.navigation)?.navigateToInstallmentChooser(expectedMethods)
     }


### PR DESCRIPTION
## Purpose

Add Installment SCB support

## Description

- Added Installment SCB support to payment methods

## Quality assurance

Make sure Installment SCB can be selected and sources can be created.

When choosing Capability API:
<img src="https://user-images.githubusercontent.com/34070466/95554673-28e33e80-0a43-11eb-9269-f92d9dc659cb.gif" alt="using capability api" width="250">

When choosing Specific payment method:
<img src="https://user-images.githubusercontent.com/34070466/95554683-2d0f5c00-0a43-11eb-92bc-68359d82ee86.gif" alt="using chosen method" width="250">


## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A