### PR TITLE
Fix build failed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
+        run: ./gradlew sdk:build -x test
+      - name: Unit tests
         run: ./gradlew sdk:testDebugUnitTest
       - name: Publish package
         run: ./gradlew uploadArchives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
+      - name: Build project
+        run: ./gradlew sdk:build -x test
+        env:
+          PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
+          PGP_SIGNING_PASSWORD: ${{ secrets.PGP_SIGNING_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
       - name: Run unit tests
         run: ./gradlew sdk:testDebugUnitTest
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,16 @@ name: Android CI
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Unit Test
+  build:
+    name: Build project
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
       - name: Build project
         run: ./gradlew sdk:build -x test
         env:
@@ -26,6 +24,16 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
 
+  test:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
       - name: Run unit tests
         run: ./gradlew sdk:testDebugUnitTest
         env:

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -16,7 +16,6 @@ android {
         buildConfigField "int", "VERSION_CODE", "$omise_sdk_code_version"
         buildConfigField "String", "VERSION_NAME", "\"$omise_sdk_version\""
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     buildTypes {
@@ -124,7 +123,6 @@ uploadArchives {
 }
 
 dependencies {
-    implementation "androidx.multidex:multidex:$multidex_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     api "joda-time:joda-time:$joda_time_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"


### PR DESCRIPTION
## Purpose

There's failed build from building the `sdk` module. That was blocked the GithubActions from auto upload the new Omise SDK version to Sonatype. So, this PR purpose to fix the failed build and able to automate the workflow again.

Related PR: #168 #167 

## Description

- Remove multidex from `build.gradle`
- Add the build step in CI/CD workflows

## Quality assurance

GithubActions shall be run all workflows without failed build.

## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A