### PR TITLE
Support build with staging environment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew sdk:build -x test
       - name: Unit tests
-        run: ./gradlew sdk:testDebugUnitTest
+        run: ./gradlew sdk:testProductionDebugUnitTest
       - name: Publish package
         run: ./gradlew uploadArchives
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Run unit tests
-        run: ./gradlew sdk:testDebugUnitTest
+        run: ./gradlew sdk:testProductionDebugUnitTest
         env:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_PASSWORD: ${{ secrets.PGP_SIGNING_PASSWORD }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,6 @@ android {
         targetSdkVersion target_sdk_version
         versionCode sample_app_code_version
         versionName sample_app_version
-        multiDexEnabled true
     }
 
     buildTypes {
@@ -22,13 +21,20 @@ android {
         }
     }
 
-    flavorDimensions "language"
+    flavorDimensions "language", "mode"
+
     productFlavors {
         java {
             dimension "language"
         }
         kotlin {
             dimension "language"
+        }
+        production {
+            dimension "mode"
+        }
+        staing {
+            dimension "mode"
         }
     }
 
@@ -47,7 +53,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "androidx.multidex:multidex:$multidex_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.preference:preference:$preference_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
         production {
             dimension "mode"
         }
-        staing {
+        staging {
             dimension "mode"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ buildscript {
         min_sdk_version = 21
         target_sdk_version = 30
 
+        omise_threeds_sdk_version = '1.0.0-alpha01'
+
         kotlin_version = '1.4.10'
         android_plugin_version = '4.1.0'
         multidex_version = '2.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
 
         kotlin_version = '1.4.10'
         android_plugin_version = '4.1.0'
-        multidex_version = '2.0.1'
         appcompat_version = '1.1.0'
         joda_time_version = '2.9.2'
         okhttp_version = '4.9.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/sample-threeds-v2-app/build.gradle
+++ b/sample-threeds-v2-app/build.gradle
@@ -12,13 +12,23 @@ android {
         targetSdkVersion target_sdk_version
         versionCode sample_app_code_version
         versionName sample_app_version
-        multiDexEnabled true
     }
 
     buildTypes {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    flavorDimensions "mode"
+
+    productFlavors {
+        production {
+            dimension "mode"
+        }
+        staing {
+            dimension "mode"
         }
     }
 
@@ -37,7 +47,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "androidx.multidex:multidex:$multidex_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.preference:preference:$preference_version"

--- a/sample-threeds-v2-app/build.gradle
+++ b/sample-threeds-v2-app/build.gradle
@@ -27,7 +27,7 @@ android {
         production {
             dimension "mode"
         }
-        staing {
+        staging {
             dimension "mode"
         }
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,6 +25,16 @@ android {
         }
     }
 
+    flavorDimensions "mode"
+    productFlavors {
+        production {
+            dimension "mode"
+        }
+        staing {
+            dimension "mode"
+        }
+    }
+
     lintOptions {
         abortOnError false
         disable 'InvalidPackage' // okio

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -123,7 +123,10 @@ uploadArchives {
 }
 
 dependencies {
-    implementation project(":3DS-ANDROID-SDK:threeds")
+//    implementation project(":3DS-ANDROID-SDK:threeds")
+    implementation("co.omise:threeds-android:$omise_threeds_sdk_version") {
+        exclude module: 'asm'
+    }
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     api "joda-time:joda-time:$joda_time_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -30,7 +30,7 @@ android {
         production {
             dimension "mode"
         }
-        staing {
+        staging {
             dimension "mode"
         }
     }

--- a/sdk/src/main/java/co/omise/android/api/EndPoint.kt
+++ b/sdk/src/main/java/co/omise/android/api/EndPoint.kt
@@ -55,9 +55,7 @@ abstract class Endpoint {
          */
         @JvmField
         val VAULT: Endpoint = object : Endpoint() {
-            override fun host(): String {
-                return "vault.omise.co"
-            }
+            override fun host(): String = OMISE_VAULT
 
             override fun authenticationKey(config: Config): String {
                 return config.publicKey()
@@ -69,9 +67,7 @@ abstract class Endpoint {
          */
         @JvmField
         val API: Endpoint = object : Endpoint() {
-            override fun host(): String {
-                return "api.omise.co"
-            }
+            override fun host(): String = OMISE_API
 
             override fun authenticationKey(config: Config): String {
                 return config.publicKey()

--- a/sdk/src/production/java/co/omise/android/api/OmiseEndpoints.kt
+++ b/sdk/src/production/java/co/omise/android/api/OmiseEndpoints.kt
@@ -1,0 +1,5 @@
+package co.omise.android.api
+
+
+internal const val OMISE_API  = "api.omise.co"
+internal const val OMISE_VAULT  = "vault.omise.co"

--- a/sdk/src/staging/java/co/omise/android/api/OmiseEndpoints.kt
+++ b/sdk/src/staging/java/co/omise/android/api/OmiseEndpoints.kt
@@ -1,5 +1,5 @@
 package co.omise.android.api
 
 
-internal const val OMISE_API = TODO("Replace with the staging api endpoint.")
-internal const val OMISE_VAULT = TODO("Replace the staging vault endpoint.")
+internal const val OMISE_API = "[ENTER_STAGING_API]"
+internal const val OMISE_VAULT = "[ENTER_STAGING_VAULT]"

--- a/sdk/src/staging/java/co/omise/android/api/OmiseEndpoints.kt
+++ b/sdk/src/staging/java/co/omise/android/api/OmiseEndpoints.kt
@@ -1,0 +1,5 @@
+package co.omise.android.api
+
+
+internal const val OMISE_API = TODO("Replace with the staging api endpoint.")
+internal const val OMISE_VAULT = TODO("Replace the staging vault endpoint.")

--- a/sdk/src/test/java/co/omise/android/ConfigurerTest.java
+++ b/sdk/src/test/java/co/omise/android/ConfigurerTest.java
@@ -41,7 +41,7 @@ public class ConfigurerTest extends OmiseTest {
     }
 
     private Request configure(Request req) {
-        return Configurer.configure$sdk_debug(config(), req);
+        return Configurer.configure$sdk_productionDebug(config(), req);
     }
 
     private Config config() {

--- a/testsupport/build.gradle
+++ b/testsupport/build.gradle
@@ -23,6 +23,15 @@ android {
         }
     }
 
+    flavorDimensions "mode"
+    productFlavors {
+        production {
+            dimension "mode"
+        }
+        staing {
+            dimension "mode"
+        }
+    }
 }
 
 dependencies {

--- a/testsupport/build.gradle
+++ b/testsupport/build.gradle
@@ -28,7 +28,7 @@ android {
         production {
             dimension "mode"
         }
-        staing {
+        staging {
             dimension "mode"
         }
     }


### PR DESCRIPTION
## Purpose

To enhance the internal testing flow to be able to build the Omise Android with staging environment.

## Description

This PR created a new `mode` dimension that contains `production` and `staging` flavors. And extracted the endpoints from the codebase to `OmiseEndpoints` file on specific build flavor path.

**For sample:** 
production: `sdk/src/production/java/co/omise/android/api/OmiseEndpoints.kt`
staging: `sdk/src/staging/java/co/omise/android/api/OmiseEndpoints.kt`

## Quality assurance

In the case you want to test with staging environment, you can change the value in `sdk/src/staging/java/co/omise/android/api/OmiseEndpoints.kt` path. And in the build variant choose `StagingDebug` in the case for debug mode. So now you can run the sample app and put the public key for staging environment and you can test create token and source.

![Screen Shot 2563-12-01 at 16 45 33](https://user-images.githubusercontent.com/2638321/100723671-a3ea2500-33f4-11eb-8754-ccdb7678a526.png)

## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A