### PR TITLE
Revise 3DS failure result

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         min_sdk_version = 21
         target_sdk_version = 30
 
-        omise_threeds_sdk_version = '1.0.0-alpha02'
+        omise_threeds_sdk_version = '1.0.0-alpha03'
 
         kotlin_version = '1.4.10'
         android_plugin_version = '4.1.0'

--- a/sdk/src/main/java/co/omise/android/OmiseError.kt
+++ b/sdk/src/main/java/co/omise/android/OmiseError.kt
@@ -1,0 +1,11 @@
+package co.omise.android
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+
+/**
+ * This class reserve for passing the Exception from Activity/Fragment through [Intent].
+ */
+@Parcelize
+data class OmiseError(val message: String, val cause: Throwable?) : Parcelable

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.ViewModelProvider
 import co.omise.android.AuthorizingPaymentURLVerifier
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.EXTRA_RETURNED_URLSTRING
 import co.omise.android.AuthorizingPaymentURLVerifier.Companion.REQUEST_EXTERNAL_CODE
+import co.omise.android.OmiseError
 import co.omise.android.R
 import co.omise.android.threeds.ui.ProgressView
 import kotlinx.android.synthetic.main.activity_authorizing_payment.authorizing_payment_webview
@@ -168,7 +169,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
 
     private fun authorizationFailed(error: Throwable? = null) {
         val errorIntent = Intent().apply {
-            putExtra(OmiseActivity.EXTRA_ERROR, error?.message)
+            putExtra(OmiseActivity.EXTRA_ERROR, OmiseError("3D Secure authentication failed.", error))
         }
         setResult(Activity.RESULT_CANCELED, errorIntent)
         finish()

--- a/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
@@ -19,6 +19,10 @@ abstract class OmiseActivity : AppCompatActivity() {
         const val EXTRA_TOKEN = "OmiseActivity.token"
         const val EXTRA_TOKEN_OBJECT = "OmiseActivity.tokenObject"
         const val EXTRA_CARD_OBJECT = "OmiseActivity.cardObject"
+
+        /**
+         * [co.omise.android.OmiseError] error object.
+         */
         const val EXTRA_ERROR = "OmiseActivity.error"
     }
 


### PR DESCRIPTION
## Purpose

This PR purpose to change the failure result from the error message to error object.

## Description

Updated the failure result from the 3DS process to return the failure object from the 3DS SDK.

## Quality assurance

N/A

## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A