### PR TITLE
Fix can not open WebView on Android 5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         kotlin_version = '1.4.10'
         android_plugin_version = '4.1.0'
         multidex_version = '2.0.1'
-        appcompat_version = '1.1.0'
+        appcompat_version = '1.2.0'
         joda_time_version = '2.9.2'
         okhttp_version = '3.12.0'
         material_version = '1.0.0'

--- a/sdk/src/main/java/co/omise/android/ui/CardNameEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CardNameEditText.kt
@@ -8,9 +8,9 @@ import android.util.AttributeSet
  * CardNameEditText is a custom EditText for the credit card name field.
  */
 class CardNameEditText : OmiseEditText {
-    constructor(context: Context?) : super(context)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     val cardName: String
         get() = text.toString().trim()

--- a/sdk/src/main/java/co/omise/android/ui/ExpiryDateEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/ExpiryDateEditText.kt
@@ -29,9 +29,9 @@ class ExpiryDateEditText : OmiseEditText {
     var expiryMonth: Int = 0
     var expiryYear: Int = 0
 
-    constructor(context: Context?) : super(context)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     init {
         addTextChangedListener(textWatcher)

--- a/sdk/src/main/java/co/omise/android/ui/OmiseEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseEditText.kt
@@ -28,11 +28,11 @@ open class OmiseEditText : AppCompatEditText {
         }
     }
 
-    constructor(context: Context?) : super(context)
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
 
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 }
 
 sealed class InputValidationException : Exception() {

--- a/sdk/src/main/java/co/omise/android/ui/SecurityCodeEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/SecurityCodeEditText.kt
@@ -18,11 +18,11 @@ class SecurityCodeEditText : OmiseEditText {
     val securityCode: String
         get() = text.toString().trim()
 
-    constructor(context: Context?) : super(context)
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
 
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     init {
         filters = arrayOf(InputFilter.LengthFilter(CVV_LENGTH))


### PR DESCRIPTION
## Purpose

To fix a bug from inflating the WebView in the AuthorizingPaymentActivity on Android 5.0.

issue: #177 

## Description

Regarding to [issue](https://issuetracker.google.com/issues/141351441#comment35) from the Appcompat version 1.1.0 that related to the crash on inflating the WebView. So, in this PR the Appcompat version was updated to use version 1.2.0 that fixed the issue. 

## Quality assurance

When authorize the `authorize_uri` with AuthorizingPaymentActivity, it shall be performed the authorization without the crash about inflating the WebView.

## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A