### PR TITLE
Maven publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Unit tests
         run: ./gradlew sdk:testProductionDebugUnitTest
       - name: Publish package
-        run: ./gradlew uploadArchives
+        run: ./gradlew sdk:publish
         env:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_PASSWORD: ${{ secrets.PGP_SIGNING_PASSWORD }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation "com.google.guava:guava:$guava_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation project(':sdk')
-    // compile 'co.omise:omise-android:2.3.+'
+//    implementation "co.omise:omise-android:$omise_sdk_version"
 
     testImplementation "junit:junit:$junit_version"
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'kotlin-android-extensions'
 
@@ -85,53 +85,102 @@ signing {
     sign configurations.archives
 }
 
-uploadArchives {
-    repositories.mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+project.afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                setGroupId 'co.omise'
+                setArtifactId 'omise-android'
+                version android.defaultConfig.versionName
+                artifact bundleProductionReleaseAar
+                pom {
+                    name = 'Omise Android SDK'
+                    description = 'Android SDK for Omise API'
+                    url = 'https://www.omise.co'
+                    withXml {
+                        def dependenciesNode = asNode().appendNode('dependencies')
+                        configurations.implementation.allDependencies.each {
+                            if (it.group != null && (it.name != null || "unspecified".equals(it.name)) && it.version != null) {
+                                def dependencyNode = dependenciesNode.appendNode('dependency')
+                                dependencyNode.appendNode('groupId', it.group)
+                                dependencyNode.appendNode('artifactId', it.name)
+                                dependencyNode.appendNode('version', it.version)
+                            }
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://git.github.com/omise/omise-android'
+                        developerConnection = 'scm:git:git://git.github.com/omise/omise-android'
+                        url = 'https://github.com/omise/omise-android'
+                    }
 
-        def ossrhUsername = System.getenv("SONATYPE_USERNAME")
-        def ossrhPassword = System.getenv("SONATYPE_PASSWORD")
+                    developers {
+                        developer {
+                            id = 'natthawut'
+                            name = 'Natthawut Haematulin'
+                            email = 'natthawut@omise.co'
+                        }
+                    }
 
-        repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-            authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-
-        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots') {
-            authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-
-        pom.project {
-            name 'Omise Android SDK'
-            description 'Android SDK for Omise API'
-            packaging 'aar'
-            groupId 'co.omise'
-            artifactId 'omise-android'
-            version omise_sdk_version
-            url 'https://www.omise.co'
-
-            scm {
-                connection 'scm:git:git://git.github.com/omise/omise-android'
-                developerConnection 'scm:git:git://git.github.com/omise/omise-android'
-                url 'https://github.com/omise/omise-android'
-            }
-
-            developers {
-                developer {
-                    id 'natthawut'
-                    name 'Natthawut Haematulin'
-                    email 'natthawut@omise.co'
-                }
-            }
-
-            licenses {
-                license {
-                    name 'The MIT License (MIT)'
-                    url 'https://opensource.org/licenses/MIT'
+                    licenses {
+                        license {
+                            name = 'The MIT License (MIT)'
+                            url = 'https://opensource.org/licenses/MIT'
+                        }
+                    }
                 }
             }
         }
     }
 }
+
+// uploadArchives {
+//    repositories.mavenDeployer {
+//        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+//
+//        def ossrhUsername = System.getenv("SONATYPE_USERNAME")
+//        def ossrhPassword = System.getenv("SONATYPE_PASSWORD")
+//
+//        repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+//            authentication(userName: ossrhUsername, password: ossrhPassword)
+//        }
+//
+//        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots') {
+//            authentication(userName: ossrhUsername, password: ossrhPassword)
+//        }
+//
+//        pom.project {
+//            name 'Omise Android SDK'
+//            description 'Android SDK for Omise API'
+//            packaging 'aar'
+//            groupId 'co.omise'
+//            artifactId 'omise-android'
+//            version omise_sdk_version
+//            url 'https://www.omise.co'
+//
+//            scm {
+//                connection 'scm:git:git://git.github.com/omise/omise-android'
+//                developerConnection 'scm:git:git://git.github.com/omise/omise-android'
+//                url 'https://github.com/omise/omise-android'
+//            }
+//
+//            developers {
+//                developer {
+//                    id 'natthawut'
+//                    name 'Natthawut Haematulin'
+//                    email 'natthawut@omise.co'
+//                }
+//            }
+//
+//            licenses {
+//                license {
+//                    name 'The MIT License (MIT)'
+//                    url 'https://opensource.org/licenses/MIT'
+//                }
+//            }
+//        }
+//    }
+//}
 
 dependencies {
 //    implementation project(":3DS-ANDROID-SDK:threeds")

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -79,9 +79,7 @@ android {
 signing {
     def signingKey = System.getenv("PGP_SIGNING_KEY")
     def signingPassword = System.getenv("PGP_SIGNING_PASSWORD")
-
     useInMemoryPgpKeys(signingKey, signingPassword)
-
     sign configurations.archives
 }
 
@@ -113,7 +111,6 @@ project.afterEvaluate {
                         developerConnection = 'scm:git:git://git.github.com/omise/omise-android'
                         url = 'https://github.com/omise/omise-android'
                     }
-
                     developers {
                         developer {
                             id = 'natthawut'
@@ -121,7 +118,6 @@ project.afterEvaluate {
                             email = 'natthawut@omise.co'
                         }
                     }
-
                     licenses {
                         license {
                             name = 'The MIT License (MIT)'
@@ -131,56 +127,22 @@ project.afterEvaluate {
                 }
             }
         }
+        repositories {
+            maven {
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+                def ossrhUsername = System.getenv("SONATYPE_USERNAME")
+                def ossrhPassword = System.getenv("SONATYPE_PASSWORD")
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
+                }
+            }
+        }
     }
 }
-
-// uploadArchives {
-//    repositories.mavenDeployer {
-//        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-//
-//        def ossrhUsername = System.getenv("SONATYPE_USERNAME")
-//        def ossrhPassword = System.getenv("SONATYPE_PASSWORD")
-//
-//        repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-//            authentication(userName: ossrhUsername, password: ossrhPassword)
-//        }
-//
-//        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots') {
-//            authentication(userName: ossrhUsername, password: ossrhPassword)
-//        }
-//
-//        pom.project {
-//            name 'Omise Android SDK'
-//            description 'Android SDK for Omise API'
-//            packaging 'aar'
-//            groupId 'co.omise'
-//            artifactId 'omise-android'
-//            version omise_sdk_version
-//            url 'https://www.omise.co'
-//
-//            scm {
-//                connection 'scm:git:git://git.github.com/omise/omise-android'
-//                developerConnection 'scm:git:git://git.github.com/omise/omise-android'
-//                url 'https://github.com/omise/omise-android'
-//            }
-//
-//            developers {
-//                developer {
-//                    id 'natthawut'
-//                    name 'Natthawut Haematulin'
-//                    email 'natthawut@omise.co'
-//                }
-//            }
-//
-//            licenses {
-//                license {
-//                    name 'The MIT License (MIT)'
-//                    url 'https://opensource.org/licenses/MIT'
-//                }
-//            }
-//        }
-//    }
-//}
 
 dependencies {
 //    implementation project(":3DS-ANDROID-SDK:threeds")


### PR DESCRIPTION
## Purpose

Since the `maven` plugin ([link](https://docs.gradle.org/current/userguide/maven_plugin.html)) is deprecated. The Omise Android SDK will not be able to publish package with `maven` plugin anymore. The Omise Android SDK needs to migrate to use `maven-publish` plugin instead.

## Description

In this PR migrated the publish configuration in the `sdk/build.gradle` file to use the `maven-publish` plugin. Also, update the command of **Maven Package** workflow to use `./gradlew sdk:publish` command.

## Quality assurance

To upload package to staging repositories on the Sonatype.
```
./gradlew sdk:publish
```

To test uploading package on your local machine. It will publish to this path `~/.m2/repository`.
```
./gradlew sdk:publishToMavenLocal
```

## Operations impact

N/A

## Pre- and post-deployment steps

N/A

## Business impact (release notes)

N/A

## Add labels and assign reviewers

N/A

## Back-out Procedure

N/A