### PR TITLE
v4.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * **ADDED:** `platform_type` field for Source
 * **ADDED:** Support for wallets: Alipay (SG), AlipayHK (SG), DANA (SG), GCash (SG), Kakao Pay (SG), Touch'n Go (SG) and Rabbit LINE Pay (TH)
 * **ADDED:** Support for installments: Citi (TH), TTB (TH), UOB (TH) and Ezypay (MY)
-* **ADDED:** Support for KBank mobile banking: Kbank (TH), Bay (TH) and OCBC Pay Anyone (SG)
+* **ADDED:** Support for mobile banking payments: Kbank (TH), Bay (TH) and OCBC Pay Anyone (SG)
 
 ## v3.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,14 @@
 # CHANGE LOG
 
-## v4.0.0-alpha07
-
-* **ADDED:** Support for Bay mobile banking
-
-## v4.0.0-alpha06
-
-* **CHANGED:** Update KBank mobile banking logo and title
-
-## v4.0.0-alpha05
-
-* **ADDED:** Support for KBank mobile banking
-* **ADDED:** Support for OCBC Pay Anyone mobile banking
-
-## v4.0.0-alpha04
-
-* **ADDED:** Support for Citi installment
-* **ADDED:** Support for TTB installment
-* **ADDED:** Support for Uob installment
-
-## v4.0.0-alpha03
-
-* **ADDED:** Support for Alipay, AlipayHK, DANA, GCash, Kakao Pay, and Touch'n Go
-* **ADDED:** `platform_type` field for Source
-
-## v4.0.0-alpha02
-
-* **ADDED:** EzyPay installment payment to Android SDK
-
-
-## v4.0.0-alpha01
+## v4.0.0
 
 * **CHANGED:** Require minimum SDK version 21
 * **ADDED:** 3D Secure version 2
 * **ADDED:** Observing `ChargeStatus` change with Token ID
+* **ADDED:** `platform_type` field for Source
+* **ADDED:** Support for wallets: Alipay (SG), AlipayHK (SG), DANA (SG), GCash (SG), Kakao Pay (SG), Touch'n Go (SG) and Rabbit LINE Pay (TH)
+* **ADDED:** Support for installments: Citi (TH), TTB (TH), UOB (TH) and Ezypay (MY)
+* **ADDED:** Support for KBank mobile banking: Kbank (TH), Bay (TH) and OCBC Pay Anyone (SG)
 
 ## v3.2.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         sample_app_version = '1.0'
         sample_app_code_version = 1
 
-        omise_sdk_version = '4.0.0-alpha07'
-        omise_sdk_code_version = 22
+        omise_sdk_version = '4.0.0'
+        omise_sdk_code_version = 23
 
         compile_sdk_version = 30
         build_tools_version = '29.0.3'


### PR DESCRIPTION
# CHANGE LOG

## v4.0.0

* **CHANGED:** Require minimum SDK version 21
* **ADDED:** 3D Secure version 2
* **ADDED:** Observing `ChargeStatus` change with Token ID
* **ADDED:** `platform_type` field for Source
* **ADDED:** Support for wallets: Alipay (SG), AlipayHK (SG), DANA (SG), GCash (SG), Kakao Pay (SG), Touch'n Go (SG) and Rabbit LINE Pay (TH)
* **ADDED:** Support for installments: Citi (TH), TTB (TH), UOB (TH) and Ezypay (MY)
* **ADDED:** Support for mobile banking payments: Kbank (TH), Bay (TH) and OCBC Pay Anyone (SG)
