### PR TITLE
Release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## v4.2.0
+* **ADDED:** Added support for Boost, DuitNow QR, DuitNow Online Banking/Wallets, Maybank QRPay and ShopeePay payment method.
+* **CHANGED** Update Touch 'n Go and Grabpay to support RMS provider.
+
 ## v4.1.4
 * **ADDED:** Added Bank of China logo for FPX payments.
 * **CHANGED** Fixed allowed installment terms for UOB and TTB installments.

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         sample_app_version = '1.0'
         sample_app_code_version = 1
 
-        omise_sdk_version = '4.1.4'
-        omise_sdk_code_version = 28
+        omise_sdk_version = '4.2.0'
+        omise_sdk_code_version = 29
 
         compile_sdk_version = 30
         build_tools_version = '29.0.3'


### PR DESCRIPTION
## v4.2.0
* **ADDED:** Added support for Boost, DuitNow QR, DuitNow Online Banking/Wallets, Maybank QRPay and ShopeePay payment method.
* **CHANGED** Update Touch 'n Go and Grabpay to support RMS provider.