### PR TITLE
[APM2-1427] Don't explicitly throw redirect error

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -99,7 +99,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
                         true
                     } catch (e: ActivityNotFoundException) {
                         e.printStackTrace()
-                        false
+                        true
                     }
                 } else {
                     false


### PR DESCRIPTION
Fix where webview explicitly throws error to user upon custome scheme navigation