### PR TITLE
4.5.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGE LOG
 
+## v4.5.1
+* **FIXED:** Patch explicit error thrown when redirecting to non-existing custom scheme uri
+
 ## v4.5.0
 * **ADDED:** Added support for Atome payment method
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         sample_app_version = '1.0'
         sample_app_code_version = 1
 
-        omise_sdk_version = '4.5.0'
-        omise_sdk_code_version = 35
+        omise_sdk_version = '4.5.1'
+        omise_sdk_code_version = 36
 
         compile_sdk_version = 30
         build_tools_version = '29.0.3'


### PR DESCRIPTION
## v4.5.1

* **FIXED:** Patch explicit error thrown when redirecting to non-existing custom scheme uri

Related PR: https://github.com/omise/omise-android/pull/243