### PR TITLE
[EM-2969] Remove KTB and SCB internet bankings

### DIFF
--- a/app/src/main/java/co/omise/android/example/PaymentSetting.kt
+++ b/app/src/main/java/co/omise/android/example/PaymentSetting.kt
@@ -15,8 +15,6 @@ object PaymentSetting {
                     R.string.payment_preference_zero_interest_installments_key,
                     R.string.payment_preference_credit_card_key,
                     R.string.payment_preference_internet_banking_bay_key,
-                    R.string.payment_preference_internet_banking_ktb_key,
-                    R.string.payment_preference_internet_banking_scb_key,
                     R.string.payment_preference_internet_banking_bbl_key,
                     R.string.payment_preference_mobile_banking_bay_key,
                     R.string.payment_preference_mobile_banking_bbl_key,
@@ -75,8 +73,6 @@ object PaymentSetting {
                 .map {
                     when (it.key) {
                         context.getString(R.string.payment_preference_internet_banking_bay_key) -> SourceType.InternetBanking.Bay
-                        context.getString(R.string.payment_preference_internet_banking_ktb_key) -> SourceType.InternetBanking.Ktb
-                        context.getString(R.string.payment_preference_internet_banking_scb_key) -> SourceType.InternetBanking.Scb
                         context.getString(R.string.payment_preference_internet_banking_bbl_key) -> SourceType.InternetBanking.Bbl
                         context.getString(R.string.payment_preference_alipay_key) -> SourceType.Alipay
                         context.getString(R.string.payment_preference_bill_payment_tesco_lotus_key) -> SourceType.BillPaymentTescoLotus

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,6 @@
     <string name="payment_preference_zero_interest_installments_key" translatable="false">zero_interest_installments</string>
     <string name="payment_preference_credit_card_key" translatable="false">credit_card</string>
     <string name="payment_preference_internet_banking_bay_key" translatable="false">internet_banking_bay</string>
-    <string name="payment_preference_internet_banking_ktb_key" translatable="false">internet_banking_ktb</string>
-    <string name="payment_preference_internet_banking_scb_key" translatable="false">internet_banking_scb</string>
     <string name="payment_preference_internet_banking_bbl_key" translatable="false">internet_banking_bbl</string>
     <string name="payment_preference_alipay_key" translatable="false">alipay</string>
     <string name="payment_preference_alipay_cn_key" translatable="false">alipay_cn</string>
@@ -73,8 +71,6 @@
     <string name="payment_preference_mobile_banking_kbank_title" translatable="false">KBANK - Mobile Banking</string>
     <string name="payment_preference_mobile_banking_ocbc_pao_title" translatable="false">OCBC Pay Anyone</string>
     <string name="payment_preference_internet_banking_bay_title" translatable="false">BAY - Internet Banking</string>
-    <string name="payment_preference_internet_banking_ktb_title" translatable="false">KTB - Internet Banking</string>
-    <string name="payment_preference_internet_banking_scb_title" translatable="false">SCB - Internet Banking</string>
     <string name="payment_preference_internet_banking_bbl_title" translatable="false">BBL - Internet Banking</string>
     <string name="payment_preference_alipay_title" translatable="false">Alipay Online</string>
     <string name="payment_preference_alipay_cn_title" translatable="false">AlipayCN</string>

--- a/app/src/main/res/xml/preference_payment_setting.xml
+++ b/app/src/main/res/xml/preference_payment_setting.xml
@@ -34,16 +34,6 @@
 
         <CheckBoxPreference
             app:defaultValue="true"
-            app:key="@string/payment_preference_internet_banking_ktb_key"
-            app:title="@string/payment_preference_internet_banking_ktb_title" />
-
-        <CheckBoxPreference
-            app:defaultValue="true"
-            app:key="@string/payment_preference_internet_banking_scb_key"
-            app:title="@string/payment_preference_internet_banking_scb_title" />
-
-        <CheckBoxPreference
-            app:defaultValue="true"
             app:key="@string/payment_preference_internet_banking_bbl_key"
             app:title="@string/payment_preference_internet_banking_bbl_title" />
 

--- a/sdk/src/main/java/co/omise/android/models/SourceType.kt
+++ b/sdk/src/main/java/co/omise/android/models/SourceType.kt
@@ -46,8 +46,6 @@ sealed class SourceType(
 
     sealed class InternetBanking(@JsonValue override val name: String?) : SourceType(name) {
         object Bay : InternetBanking("internet_banking_bay")
-        object Ktb : InternetBanking("internet_banking_ktb")
-        object Scb : InternetBanking("internet_banking_scb")
         object Bbl : InternetBanking("internet_banking_bbl")
         data class Unknown(@JsonValue override val name: String?) : InternetBanking(name)
     }
@@ -97,8 +95,6 @@ sealed class SourceType(
         @JvmStatic
         fun creator(name: String?): SourceType = when (name) {
             "internet_banking_bay" -> InternetBanking.Bay
-            "internet_banking_ktb" -> InternetBanking.Ktb
-            "internet_banking_scb" -> InternetBanking.Scb
             "internet_banking_bbl" -> InternetBanking.Bbl
             "mobile_banking_bay" -> MobileBanking.Bay
             "mobile_banking_bbl" -> MobileBanking.Bbl
@@ -157,8 +153,6 @@ object SourceTypeParceler : Parceler<SourceType> {
 val SourceType.Companion.allElements: List<SourceType>
     get() = listOf(
             SourceType.InternetBanking.Bay,
-            SourceType.InternetBanking.Ktb,
-            SourceType.InternetBanking.Scb,
             SourceType.InternetBanking.Bbl,
             SourceType.Alipay,
             SourceType.BillPaymentTescoLotus,

--- a/sdk/src/main/java/co/omise/android/ui/PaymentMethodResources.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentMethodResources.kt
@@ -424,25 +424,11 @@ internal sealed class InternetBankingResource(
             sourceType = SourceType.InternetBanking.Bbl
     )
 
-    object Scb : InternetBankingResource(
-            iconRes = R.drawable.payment_scb,
-            titleRes = R.string.payment_method_internet_banking_scb_title,
-            indicatorIconRes = R.drawable.ic_redirect,
-            sourceType = SourceType.InternetBanking.Scb
-    )
-
     object Bay : InternetBankingResource(
             iconRes = R.drawable.payment_bay,
             titleRes = R.string.payment_method_internet_banking_bay_title,
             indicatorIconRes = R.drawable.ic_redirect,
             sourceType = SourceType.InternetBanking.Bay
-    )
-
-    object Ktb : InternetBankingResource(
-            iconRes = R.drawable.payment_ktb,
-            titleRes = R.string.payment_method_internet_banking_ktb_title,
-            indicatorIconRes = R.drawable.ic_redirect,
-            sourceType = SourceType.InternetBanking.Ktb
     )
 }
 

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -74,8 +74,6 @@
     <string name="payment_method_internet_banking_bay_title">アユタヤ銀行</string>
     <string name="payment_method_internet_banking_bbl_title">バンコク銀行</string>
     <string name="payment_method_mobile_banking_scb_title">SCB EASY</string>
-    <string name="payment_method_internet_banking_ktb_title">クルンタイ銀行</string>
-    <string name="payment_method_internet_banking_scb_title">サイアム・コマーシャル銀行</string>
     <string name="payment_method_installment_citi_title">シティバンク</string>
     <string name="payment_method_installment_ttb_title">TMBタナチャート銀行</string>
     <string name="payment_method_installment_uob_title">ユナイテッド・オーバーシーズ銀行</string>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -77,8 +77,6 @@
     <string name="payment_method_internet_banking_bay_title">ธนาคารกรุงศรีอยุธยา</string>
     <string name="payment_method_internet_banking_bbl_title">ธนาคารกรุงเทพ</string>
     <string name="payment_method_mobile_banking_scb_title">SCB EASY</string>
-    <string name="payment_method_internet_banking_ktb_title">ธนาคารกรุงไทย</string>
-    <string name="payment_method_internet_banking_scb_title">ธนาคารไทยพาณิชย์</string>
     <string name="payment_method_internet_banking_title">อินเทอร์เน็ตแบงก์กิ้ง</string>
     <string name="payment_method_mobile_banking_title">โมบายแบงก์กิ้ง</string>
     <string name="payment_method_netbank_title">เน็ตแบงก์</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -94,8 +94,6 @@
 
     <string name="payment_method_internet_banking_bay_title">Bank of Ayudhya</string>
     <string name="payment_method_internet_banking_bbl_title">Bangkok Bank</string>
-    <string name="payment_method_internet_banking_scb_title">Siam Commercial Bank</string>
-    <string name="payment_method_internet_banking_ktb_title">Krungthai Bank</string>
     <string name="payment_method_promptpay_title">PromptPay</string>
     <string name="payment_method_paynow_title">PayNow</string>
     <string name="payment_method_points_citi_title">Pay with Citi Rewards Points</string>

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InternetBankingChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InternetBankingChooserFragmentTest.kt
@@ -48,7 +48,7 @@ class InternetBankingChooserFragmentTest {
     @Test
     fun displayAllowedBanks_showAllowedBanksFromArgument() {
         onView(withListId(R.id.recycler_view).atPosition(0)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_bbl_title))))
-        onView(withListId(R.id.recycler_view).atPosition(2)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_bay_title))))
+        onView(withListId(R.id.recycler_view).atPosition(1)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_bay_title))))
         onView(withId(R.id.recycler_view)).check(matches(itemCount(paymentMethods.size)))
     }
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/InternetBankingChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/InternetBankingChooserFragmentTest.kt
@@ -31,9 +31,7 @@ class InternetBankingChooserFragmentTest {
     private lateinit var fragment: InternetBankingChooserFragment
     private val paymentMethods = listOf(
             PaymentMethod(name = "internet_banking_bbl"),
-            PaymentMethod(name = "internet_banking_scb"),
-            PaymentMethod(name = "internet_banking_bay"),
-            PaymentMethod(name = "internet_banking_ktb")
+            PaymentMethod(name = "internet_banking_bay")
     )
     private val mockRequest = mock<PaymentCreatorRequester<Source>> {
         on { amount }.doReturn(500000L)
@@ -50,9 +48,7 @@ class InternetBankingChooserFragmentTest {
     @Test
     fun displayAllowedBanks_showAllowedBanksFromArgument() {
         onView(withListId(R.id.recycler_view).atPosition(0)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_bbl_title))))
-        onView(withListId(R.id.recycler_view).atPosition(1)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_scb_title))))
         onView(withListId(R.id.recycler_view).atPosition(2)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_bay_title))))
-        onView(withListId(R.id.recycler_view).atPosition(3)).check(matches(hasDescendant(withText(R.string.payment_method_internet_banking_ktb_title))))
         onView(withId(R.id.recycler_view)).check(matches(itemCount(paymentMethods.size)))
     }
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -60,8 +60,6 @@ class PaymentChooserFragmentTest {
             PaymentMethod(name = "installment_uob"),
             PaymentMethod(name = "internet_banking_bay"),
             PaymentMethod(name = "internet_banking_bbl"),
-            PaymentMethod(name = "internet_banking_ktb"),
-            PaymentMethod(name = "internet_banking_scb"),
             PaymentMethod(name = "bill_payment_tesco_lotus"),
             PaymentMethod(name = "econtext"),
             PaymentMethod(name = "alipay"),
@@ -193,9 +191,7 @@ class PaymentChooserFragmentTest {
 
         val expectedMethods = listOf(
             PaymentMethod(name = "internet_banking_bay"),
-            PaymentMethod(name = "internet_banking_bbl"),
-            PaymentMethod(name = "internet_banking_ktb"),
-            PaymentMethod(name = "internet_banking_scb")
+            PaymentMethod(name = "internet_banking_bbl")
         )
         verify(fragment.navigation)?.navigateToInternetBankingChooser(expectedMethods)
     }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -59,8 +59,6 @@ class PaymentChooserFragmentTest {
             PaymentMethod(name = "installment_ttb"),
             PaymentMethod(name = "installment_uob"),
             PaymentMethod(name = "internet_banking_bay"),
-            PaymentMethod(name = "internet_banking_bbl"),
-            PaymentMethod(name = "internet_banking_ktb"),
             PaymentMethod(name = "internet_banking_scb"),
             PaymentMethod(name = "bill_payment_tesco_lotus"),
             PaymentMethod(name = "econtext"),
@@ -193,9 +191,7 @@ class PaymentChooserFragmentTest {
 
         val expectedMethods = listOf(
             PaymentMethod(name = "internet_banking_bay"),
-            PaymentMethod(name = "internet_banking_bbl"),
-            PaymentMethod(name = "internet_banking_ktb"),
-            PaymentMethod(name = "internet_banking_scb")
+            PaymentMethod(name = "internet_banking_bbl")
         )
         verify(fragment.navigation)?.navigateToInternetBankingChooser(expectedMethods)
     }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentChooserFragmentTest.kt
@@ -59,6 +59,8 @@ class PaymentChooserFragmentTest {
             PaymentMethod(name = "installment_ttb"),
             PaymentMethod(name = "installment_uob"),
             PaymentMethod(name = "internet_banking_bay"),
+            PaymentMethod(name = "internet_banking_bbl"),
+            PaymentMethod(name = "internet_banking_ktb"),
             PaymentMethod(name = "internet_banking_scb"),
             PaymentMethod(name = "bill_payment_tesco_lotus"),
             PaymentMethod(name = "econtext"),
@@ -191,7 +193,9 @@ class PaymentChooserFragmentTest {
 
         val expectedMethods = listOf(
             PaymentMethod(name = "internet_banking_bay"),
-            PaymentMethod(name = "internet_banking_bbl")
+            PaymentMethod(name = "internet_banking_bbl"),
+            PaymentMethod(name = "internet_banking_ktb"),
+            PaymentMethod(name = "internet_banking_scb")
         )
         verify(fragment.navigation)?.navigateToInternetBankingChooser(expectedMethods)
     }


### PR DESCRIPTION
To remove KTB and SCB internet bankings, regarding the SCB and KTB internet banking decommission.

Task: https://opn-ooo.atlassian.net/browse/EM-2786

Results: 
SCB and KTB internet banking do not appear in payment methods selection both user setting page and payment page.

<img width="300" alt="Screen Shot 2023-01-12 at 2 51 46 PM" src="https://user-images.githubusercontent.com/32503471/212010355-876a9728-3d55-41a2-af81-a3e1dfab4735.png">   <img width="300" alt="Screen Shot 2023-01-12 at 2 52 07 PM" src="https://user-images.githubusercontent.com/32503471/212010322-a1243e6d-940b-44ce-9f4b-98f5fb390a24.png"> 
