### PR TITLE
[MIT-1378] Upgrade 3DS-SDK version 1.0.0-alpha12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
       - name: Build project
         run: ./gradlew sdk:build -x test
         env:
@@ -29,11 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
       - name: Run unit tests
         run: ./gradlew sdk:testProductionDebugUnitTest
         env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion compile_sdk_version
-    buildToolsVersion build_tools_version
 
     defaultConfig {
         applicationId "co.omise.android.example"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.preference:preference:$preference_version"
     implementation "com.google.android.material:material:$material_version"
-    implementation "com.google.guava:guava:$guava_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation project(':sdk')
 //    implementation "co.omise:omise-android:$omise_sdk_version"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         min_sdk_version = 21
         target_sdk_version = 30
 
-        omise_threeds_sdk_version = '1.0.0-alpha11'
+        omise_threeds_sdk_version = '1.0.0-alpha12'
 
         kotlin_version = '1.7.10'
         android_plugin_version = '7.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 
         omise_threeds_sdk_version = '1.0.0-alpha11'
 
-        kotlin_version = '1.4.10'
-        android_plugin_version = '4.1.2'
+        kotlin_version = '1.7.10'
+        android_plugin_version = '7.4.2'
         appcompat_version = '1.2.0'
         joda_time_version = '2.9.2'
         okhttp_version = '4.9.0'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -6,13 +6,10 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion compile_sdk_version
-    buildToolsVersion build_tools_version
 
     defaultConfig {
         minSdkVersion min_sdk_version
         targetSdkVersion target_sdk_version
-        versionCode omise_sdk_code_version
-        versionName omise_sdk_version
         buildConfigField "int", "VERSION_CODE", "$omise_sdk_code_version"
         buildConfigField "String", "VERSION_NAME", "\"$omise_sdk_version\""
         testInstrumentationRunner "co.omise.android.OmiseTestRunner"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,6 +10,8 @@ android {
     defaultConfig {
         minSdkVersion min_sdk_version
         targetSdkVersion target_sdk_version
+        versionCode omise_sdk_code_version
+        versionName omise_sdk_version
         buildConfigField "int", "VERSION_CODE", "$omise_sdk_code_version"
         buildConfigField "String", "VERSION_NAME", "\"$omise_sdk_version\""
         testInstrumentationRunner "co.omise.android.OmiseTestRunner"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -183,7 +183,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     androidTestImplementation "androidx.annotation:annotation:$annotation_version"
-    androidTestImplementation "com.google.guava:guava:$guava_version"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
     androidTestImplementation "org.robolectric:annotations:$robolectric_version"
     androidTestImplementation "org.mockito:mockito-android:$mockito_version"

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -52,13 +52,13 @@ internal class PaymentChooserFragment : OmiseListFragment<PaymentMethodResource>
             PaymentMethodResource.MaybankQR,
             PaymentMethodResource.GrabPay,
             PaymentMethodResource.PayPay,
-            PaymentMethodResource.PointsCiti -> item.sourceType?.let(::sendRequest)
+            PaymentMethodResource.PointsCiti,
+            PaymentMethodResource.GrabPay_RMS,
+            PaymentMethodResource.TouchNGo_Alipay -> item.sourceType?.let(::sendRequest)
             PaymentMethodResource.Fpx -> navigation.navigateToFpxEmailForm()
             PaymentMethodResource.GooglePay -> navigation.navigateToGooglePayForm()
             PaymentMethodResource.DuitNowOBW -> navigation.navigateToDuitNowOBWBankChooser()
             PaymentMethodResource.Atome -> navigation.navigateToAtomeForm()
-            PaymentMethodResource.GrabPay_RMS -> TODO()
-            PaymentMethodResource.TouchNGo_Alipay -> TODO()
         }
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -57,6 +57,8 @@ internal class PaymentChooserFragment : OmiseListFragment<PaymentMethodResource>
             PaymentMethodResource.GooglePay -> navigation.navigateToGooglePayForm()
             PaymentMethodResource.DuitNowOBW -> navigation.navigateToDuitNowOBWBankChooser()
             PaymentMethodResource.Atome -> navigation.navigateToAtomeForm()
+            PaymentMethodResource.GrabPay_RMS -> TODO()
+            PaymentMethodResource.TouchNGo_Alipay -> TODO()
         }
     }
 

--- a/testsupport/build.gradle
+++ b/testsupport/build.gradle
@@ -3,14 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.2"
 
 
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'


### PR DESCRIPTION
This PR upgraded `threeds-android` dependency to vresion 1.0.0-alpha12. 

**Minimum requirements**
- Kotlin version 1.7.10 or above.
- Android gradle plugin version 7.4.2 or above.