### PR TITLE
Upgrade JDK to version 11 on CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,11 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Grant execute permission for gradlew

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,10 +3,9 @@
 
 name: Maven Package
 
-#on:
-#  release:
-#    types: [created]
-on: [pull_request]
+on:
+  release:
+    types: [created]
 
 jobs:
   publish:
@@ -28,8 +27,8 @@ jobs:
         run: ./gradlew sdk:build -x test
       - name: Unit tests
         run: ./gradlew sdk:testProductionDebugUnitTest
-#      - name: Publish package
-#        run: ./gradlew sdk:publish
+      - name: Publish package
+        run: ./gradlew sdk:publish
         env:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_PASSWORD: ${{ secrets.PGP_SIGNING_PASSWORD }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ name: Maven Package
 #on:
 #  release:
 #    types: [created]
+on: [pull_request]
 
 jobs:
   publish:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,9 +3,9 @@
 
 name: Maven Package
 
-on:
-  release:
-    types: [created]
+#on:
+#  release:
+#    types: [created]
 
 jobs:
   publish:
@@ -27,8 +27,8 @@ jobs:
         run: ./gradlew sdk:build -x test
       - name: Unit tests
         run: ./gradlew sdk:testProductionDebugUnitTest
-      - name: Publish package
-        run: ./gradlew sdk:publish
+#      - name: Publish package
+#        run: ./gradlew sdk:publish
         env:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_PASSWORD: ${{ secrets.PGP_SIGNING_PASSWORD }}


### PR DESCRIPTION
Due to a build failed on CD pipeline [link](https://github.com/omise/omise-android/actions/runs/5262682228), this PR upgrades JDK to version 11 because AGP 7.4 is no longer supported JDK 1.8. 