### PR TITLE
[MIT-1925] Fix app crash from progress view

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -85,10 +85,10 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         }
 
         viewModel.isLoading.observe(this) {
+            // Closing transaction will also hide the progress view.
+            // So, we only show the progress view.
             if (it) {
                 viewModel.getTransaction().getProgressView(this).showProgress()
-            } else {
-                viewModel.getTransaction().getProgressView(this).hideProgress()
             }
         }
 


### PR DESCRIPTION
In order to fix the app crash when hiding after closing the transaction, so we can remove calling `hideProgress()` because when closing the transaction it will also hide the progress view.