### PR TITLE
[MIT-1845] Add FLAG_SECURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ If you enable ProGuard, then add this rules in your ProGuard file.
 
 ## Protecting screenshot and screen recording
 
-To protect **Omise Android SDK** from being screenshot and screen recording, you can pass this `OmiseActivity.EXTRA_IS_SECURE` extra data to `true` when starting these activities `CreditCardActivity`, `PaymentCreatorActivity`, and `AuthorizingPaymentActivity`. By default it is `false`.
+By default, **Omise Android SDK** protects the screen from being screenshot and screen recording, if you want to disable this feature you can pass this `OmiseActivity.EXTRA_IS_SECURE` extra data to `false` when starting these activities `CreditCardActivity`, `PaymentCreatorActivity`, and `AuthorizingPaymentActivity`.
 
 ```kotlin
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ If you enable ProGuard, then add this rules in your ProGuard file.
 
 ## Protecting screenshot and screen recording
 
-By default, **Omise Android SDK** protects the screen from being screenshot and screen recording, if you want to disable this feature you can pass this `OmiseActivity.EXTRA_IS_SECURE` extra data to `false` when starting these activities `CreditCardActivity`, `PaymentCreatorActivity`, and `AuthorizingPaymentActivity`.
+**Omise Android SDK** comes with built-in protection against screenshoot and screen recording. If you wish to disable this feature, you can pass `OmiseActivity.EXTRA_IS_SECURE` with a value of `false` when starting the following activities: `CreditCardActivity`, `PaymentCreatorActivity`, and `AuthorizingPaymentActivity`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,12 @@ If you enable ProGuard, then add this rules in your ProGuard file.
 -keep class com.nimbusds.jose.** { *; }
 ```
 
+## Protecting screenshot and screen recording
+
+To protect **Omise Android SDK** from being screenshot and screen recording, you can pass this `OmiseActivity.EXTRA_IS_SECURE` extra data to `true` when starting these activities `CreditCardActivity`, `PaymentCreatorActivity`, and `AuthorizingPaymentActivity`. By default it is `false`.
+
+```kotlin
+
 ## Contributing
 
 Pull requests and bug fixes are welcome. For larger scope of work, please pop on to our [forum](https://forum.omise.co) to discuss first.

--- a/README.md
+++ b/README.md
@@ -525,8 +525,6 @@ If you enable ProGuard, then add this rules in your ProGuard file.
 
 By default, **Omise Android SDK** protects the screen from being screenshot and screen recording, if you want to disable this feature you can pass this `OmiseActivity.EXTRA_IS_SECURE` extra data to `false` when starting these activities `CreditCardActivity`, `PaymentCreatorActivity`, and `AuthorizingPaymentActivity`.
 
-```kotlin
-
 ## Contributing
 
 Pull requests and bug fixes are welcome. For larger scope of work, please pop on to our [forum](https://forum.omise.co) to discuss first.

--- a/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import android.net.Uri
+import android.view.WindowManager
 import android.widget.ProgressBar
 import androidx.arch.core.executor.testing.CountingTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
@@ -330,5 +331,13 @@ class AuthorizingPaymentActivityTest {
                 hasData(Uri.parse(deepLinkAuthorizeUrl))
             )
         )
+    }
+
+    @Test
+    fun flagSecure_activityShouldContainFlagSecureInAttributes() {
+        val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
+        scenario.onActivity {
+            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }

--- a/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
@@ -335,19 +335,19 @@ class AuthorizingPaymentActivityTest {
     }
 
     @Test
-    fun flagSecure_whenSetParameterThenAttributesMustContainFlagSecure() {
-        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, true)
+    fun flagSecure_whenParameterIsFalseThenAttributesMustNotContainFlagSecure() {
+        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, false)
         val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
         scenario.onActivity {
-            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 
     @Test
-    fun flagSecure_whenNotSetParameterThenAttributesMustNotContainFlagSecure() {
+    fun flagSecure_whenParameterNotSetThenAttributesMustContainFlagSecure() {
         val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
         scenario.onActivity {
-            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 }

--- a/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
@@ -56,6 +56,7 @@ import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -334,10 +335,19 @@ class AuthorizingPaymentActivityTest {
     }
 
     @Test
-    fun flagSecure_activityShouldContainFlagSecureInAttributes() {
+    fun flagSecure_whenSetParameterThenAttributesMustContainFlagSecure() {
+        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, true)
         val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
         scenario.onActivity {
             assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    @Test
+    fun flagSecure_whenNotSetParameterThenAttributesMustNotContainFlagSecure() {
+        val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
+        scenario.onActivity {
+            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import android.webkit.CookieManager
 import android.webkit.JsPromptResult
 import android.webkit.JsResult
@@ -54,6 +55,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContentView(R.layout.activity_authorizing_payment)
 
         supportActionBar?.title = threeDSConfig.uiCustomization?.toolbarCustomization?.headerText

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -55,7 +55,11 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+        if (intent.getBooleanExtra(OmiseActivity.EXTRA_IS_SECURE, false)) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+
         setContentView(R.layout.activity_authorizing_payment)
 
         supportActionBar?.title = threeDSConfig.uiCustomization?.toolbarCustomization?.headerText

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -56,7 +56,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (intent.getBooleanExtra(OmiseActivity.EXTRA_IS_SECURE, false)) {
+        if (intent.getBooleanExtra(OmiseActivity.EXTRA_IS_SECURE, true)) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
 

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -125,7 +125,11 @@ class CreditCardActivity : OmiseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+        if (intent.getBooleanExtra(EXTRA_IS_SECURE, false)) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+
         setContentView(R.layout.activity_credit_card)
 
         require(intent.hasExtra(EXTRA_PKEY)) { "Could not find ${::EXTRA_PKEY.name}." }

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -126,7 +126,7 @@ class CreditCardActivity : OmiseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (intent.getBooleanExtra(EXTRA_IS_SECURE, false)) {
+        if (intent.getBooleanExtra(EXTRA_IS_SECURE, true)) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
 

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageButton
@@ -124,7 +125,7 @@ class CreditCardActivity : OmiseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContentView(R.layout.activity_credit_card)
 
         require(intent.hasExtra(EXTRA_PKEY)) { "Could not find ${::EXTRA_PKEY.name}." }

--- a/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/OmiseActivity.kt
@@ -23,6 +23,12 @@ abstract class OmiseActivity : AppCompatActivity() {
         const val EXTRA_TOKEN = "OmiseActivity.token"
         const val EXTRA_TOKEN_OBJECT = "OmiseActivity.tokenObject"
         const val EXTRA_CARD_OBJECT = "OmiseActivity.cardObject"
+
+        /**
+         * Applies [android.view.WindowManager.LayoutParams.FLAG_SECURE] to the activity.
+         * This will prevent the activity from being captured by screenshots and video recordings.
+         */
+        const val EXTRA_IS_SECURE = "OmiseActivity.isSecure"
     }
 
     @VisibleForTesting

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -3,7 +3,7 @@ package co.omise.android.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
+import android.view.WindowManager
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import co.omise.android.R
@@ -64,6 +64,7 @@ class PaymentCreatorActivity : OmiseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContentView(R.layout.activity_payment_creator)
 
         initialize()

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -66,7 +66,7 @@ class PaymentCreatorActivity : OmiseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (intent.getBooleanExtra(EXTRA_IS_SECURE, false)) {
+        if (intent.getBooleanExtra(EXTRA_IS_SECURE, true)) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
 
@@ -207,7 +207,7 @@ private class PaymentCreatorNavigationImpl(
     override fun navigateToCreditCardForm() {
         val intent = Intent(activity, CreditCardActivity::class.java).apply {
             putExtra(EXTRA_PKEY, pkey)
-            putExtra(EXTRA_IS_SECURE, activity.intent.getBooleanExtra(EXTRA_IS_SECURE, false))
+            putExtra(EXTRA_IS_SECURE, activity.intent.getBooleanExtra(EXTRA_IS_SECURE, true))
         }
         activity.startActivityForResult(intent, requestCode)
     }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -18,6 +18,7 @@ import co.omise.android.ui.OmiseActivity.Companion.EXTRA_CURRENCY
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_GOOGLEPAY_MERCHANT_ID
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_GOOGLEPAY_REQUEST_BILLING_ADDRESS
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_GOOGLEPAY_REQUEST_PHONE_NUMBER
+import co.omise.android.ui.OmiseActivity.Companion.EXTRA_IS_SECURE
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_PKEY
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_SOURCE_OBJECT
 import com.google.android.material.snackbar.Snackbar
@@ -64,7 +65,11 @@ class PaymentCreatorActivity : OmiseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+        if (intent.getBooleanExtra(EXTRA_IS_SECURE, false)) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+
         setContentView(R.layout.activity_payment_creator)
 
         initialize()
@@ -202,6 +207,7 @@ private class PaymentCreatorNavigationImpl(
     override fun navigateToCreditCardForm() {
         val intent = Intent(activity, CreditCardActivity::class.java).apply {
             putExtra(EXTRA_PKEY, pkey)
+            putExtra(EXTRA_IS_SECURE, activity.intent.getBooleanExtra(EXTRA_IS_SECURE, false))
         }
         activity.startActivityForResult(intent, requestCode)
     }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launchActivityForResult
@@ -46,6 +47,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.internal.stubbing.answers.AnswersWithDelay
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -54,7 +56,6 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
-@Ignore
 class CreditCardActivityTest {
 
     private lateinit var scenario: ActivityScenario<CreditCardActivity>
@@ -294,6 +295,7 @@ class CreditCardActivityTest {
     }
 
     @Test
+    @Ignore("Test failed")
     fun submitForm_disableFormWhenPressSubmit() {
         whenever(mockClient.send<Token>(any(), any())).doAnswer { invocation ->
             val callback = invocation.getArgument<RequestListener<Token>>(1)
@@ -385,6 +387,15 @@ class CreditCardActivityTest {
         pressBackUnconditionally()
         val result = scenario.result
         assertEquals(RESULT_CANCELED, result.resultCode)
+    }
+
+
+    @Test
+    fun flagSecure_activityShouldContainFlagSecureInAttributes() {
+        val scenario = launchActivityForResult<CreditCardActivity>(intent)
+        scenario.onActivity {
+            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }
 

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -44,10 +44,8 @@ import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.internal.stubbing.answers.AnswersWithDelay
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -295,12 +293,8 @@ class CreditCardActivityTest {
     }
 
     @Test
-    @Ignore("Test failed")
     fun submitForm_disableFormWhenPressSubmit() {
-        whenever(mockClient.send<Token>(any(), any())).doAnswer { invocation ->
-            val callback = invocation.getArgument<RequestListener<Token>>(1)
-            callback.onRequestSucceed(Token())
-        }
+        whenever(mockClient.send<Token>(any(), any())).doAnswer {}
         onView(withId(R.id.edit_card_number)).perform(typeText("4242424242424242"))
         onView(withId(R.id.edit_card_name)).perform(typeText("John Doe"))
         onView(withId(R.id.edit_expiry_date)).perform(typeText("1234"))

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -43,6 +43,7 @@ import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -385,10 +386,19 @@ class CreditCardActivityTest {
 
 
     @Test
-    fun flagSecure_activityShouldContainFlagSecureInAttributes() {
+    fun flagSecure_whenSetParameterThenAttributesMustContainFlagSecure() {
+        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, true)
         val scenario = launchActivityForResult<CreditCardActivity>(intent)
         scenario.onActivity {
             assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    @Test
+    fun flagSecure_whenNotSetParameterThenAttributesMustNotContainFlagSecure() {
+        val scenario = launchActivityForResult<CreditCardActivity>(intent)
+        scenario.onActivity {
+            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/CreditCardActivityTest.kt
@@ -384,21 +384,20 @@ class CreditCardActivityTest {
         assertEquals(RESULT_CANCELED, result.resultCode)
     }
 
-
     @Test
-    fun flagSecure_whenSetParameterThenAttributesMustContainFlagSecure() {
-        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, true)
-        val scenario = launchActivityForResult<CreditCardActivity>(intent)
+    fun flagSecure_whenParameterIsFalseThenAttributesMustNotContainFlagSecure() {
+        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, false)
+        val scenario = ActivityScenario.launchActivityForResult<CreditCardActivity>(intent)
         scenario.onActivity {
-            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 
     @Test
-    fun flagSecure_whenNotSetParameterThenAttributesMustNotContainFlagSecure() {
-        val scenario = launchActivityForResult<CreditCardActivity>(intent)
+    fun flagSecure_whenParameterNotSetThenAttributesMustContainFlagSecure() {
+        val scenario = ActivityScenario.launchActivityForResult<CreditCardActivity>(intent)
         scenario.onActivity {
-            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -2,6 +2,7 @@ package co.omise.android.ui
 
 import android.app.Activity.RESULT_OK
 import android.content.Intent
+import android.view.WindowManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -9,7 +10,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
-import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -26,9 +27,8 @@ import org.junit.runner.RunWith
 class PaymentCreatorActivityTest {
 
     @get:Rule
-    val intentRule = IntentsTestRule<TestFragmentActivity>(TestFragmentActivity::class.java)
+    val intentRule = IntentsRule()
 
-    private lateinit var scenario: ActivityScenario<PaymentCreatorActivity>
     private val capability = Capability()
     private val intent = Intent(
             ApplicationProvider.getApplicationContext(),
@@ -42,7 +42,7 @@ class PaymentCreatorActivityTest {
 
     @Test
     fun initialActivity_collectExtrasIntent() {
-        scenario = ActivityScenario.launch(intent)
+        ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
 
         onView(withId(R.id.payment_creator_container)).check(matches(isDisplayed()))
     }
@@ -50,7 +50,7 @@ class PaymentCreatorActivityTest {
     @Test
     fun navigateToCreditCardForm_startCreditCartActivity() {
         var activity: PaymentCreatorActivity? = null
-        scenario = ActivityScenario.launch<PaymentCreatorActivity>(intent).onActivity {
+        ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent).onActivity {
             activity = it
         }
 
@@ -64,10 +64,18 @@ class PaymentCreatorActivityTest {
         val creditCardIntent = Intent().apply {
             putExtra(EXTRA_TOKEN, Token())
         }
-        scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent).onActivity {
+        val scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent).onActivity {
             it.performActivityResult(100, RESULT_OK, creditCardIntent)
         }
 
         assertEquals(RESULT_OK, scenario.result.resultCode)
+    }
+
+    @Test
+    fun flagSecure_activityShouldContainFlagSecureInAttributes() {
+        val scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
+        scenario.onActivity {
+            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -74,19 +74,19 @@ class PaymentCreatorActivityTest {
     }
 
     @Test
-    fun flagSecure_whenSetParameterThenAttributesMustContainFlagSecure() {
-        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, true)
+    fun flagSecure_whenParameterIsFalseThenAttributesMustNotContainFlagSecure() {
+        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, false)
         val scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
         scenario.onActivity {
-            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 
     @Test
-    fun flagSecure_whenNotSetParameterThenAttributesMustNotContainFlagSecure() {
+    fun flagSecure_whenParameterNotSetThenAttributesMustContainFlagSecure() {
         val scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
         scenario.onActivity {
-            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+            assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 }

--- a/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/sharedTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -18,7 +18,9 @@ import co.omise.android.R
 import co.omise.android.models.Capability
 import co.omise.android.models.Token
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_TOKEN
+import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -72,10 +74,19 @@ class PaymentCreatorActivityTest {
     }
 
     @Test
-    fun flagSecure_activityShouldContainFlagSecureInAttributes() {
+    fun flagSecure_whenSetParameterThenAttributesMustContainFlagSecure() {
+        intent.putExtra(OmiseActivity.EXTRA_IS_SECURE, true)
         val scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
         scenario.onActivity {
             assertEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    @Test
+    fun flagSecure_whenNotSetParameterThenAttributesMustNotContainFlagSecure() {
+        val scenario = ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
+        scenario.onActivity {
+            assertNotEquals(WindowManager.LayoutParams.FLAG_SECURE, it.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 }


### PR DESCRIPTION
Added `FLAG_SECURE` to these below Activity classes to prevent screenshot.
- CreditCardActivity
- PaymentCreatorActivity
- AuthorizingPaymentActivity

<img src="https://github.com/omise/omise-android/assets/2638321/e048d4f6-c38e-4bc6-9780-cd3442dd7902" width="400" />


