### PR TITLE
Enable webview for legacy payments

### DIFF
--- a/app/src/java/java/co/omise/android/example/CheckoutActivity.java
+++ b/app/src/java/java/co/omise/android/example/CheckoutActivity.java
@@ -230,6 +230,11 @@ public class CheckoutActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // custom result code when web view is closed
+        if (resultCode == AuthorizingPaymentActivity.WEBVIEW_CLOSED_RESULT_CODE) {
+            snackbar.setText(R.string.webview_closed).show();
+            return;
+        }
         if (resultCode == RESULT_CANCELED) {
             snackbar.setText(R.string.payment_cancelled).show();
             return;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="format_price" formatted="false" translatable="false">THB %.2f</string>
     <string name="menu_title_setup" translatable="false">Setup</string>
     <string name="payment_cancelled" translatable="false">Payment creation cancelled</string>
+    <string name="webview_closed" translatable="false">The webView has been closed</string>
     <string name="button_choose_payment_method" translatable="false">Choose Payment Method</string>
     <string name="button_pay_by_credit_card" translatable="false">Pay by Credit Card</string>
     <string name="button_authorize_url" translatable="false">Authorize URL</string>

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -56,21 +56,8 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_authorizing_payment)
-
-        supportActionBar?.title = uiCustomization.uiCustomization.toolbarCustomization?.headerText
-            ?: getString(R.string.title_authorizing_payment)
-
-        val authUrl = verifier.authorizedURLString
-        // check for legacy payments that require web view
-        if (authUrl.endsWith("/pay")) {
-            setupWebView()
-        } else {
-            // Check if the URL needs to be opened externally
-            if (verifier.verifyExternalURL(verifier.authorizedURL)) {
-                openDeepLink(verifier.authorizedURL)
-            }
-            observeData()
-        }
+        setupActionBarTitle()
+        handlePaymentAuthorization()
     }
 
     @TestOnly
@@ -185,6 +172,25 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         }
     }
 
+    private fun setupActionBarTitle() {
+        supportActionBar?.title = uiCustomization.uiCustomization.toolbarCustomization?.headerText
+            ?: getString(R.string.title_authorizing_payment)
+    }
+
+    private fun handlePaymentAuthorization() {
+        val authUrlString = verifier.authorizedURLString
+        val authUrl=verifier.authorizedURL
+        // check for legacy payments that require web view
+        if (authUrlString.endsWith("/pay")) {
+            setupWebView()
+        } else {
+            // Check if the URL needs to be opened externally
+            if (verifier.verifyExternalURL(authUrl)) {
+                openDeepLink(authUrl)
+            }
+            observeData()
+        }
+    }
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_EXTERNAL_CODE) {

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -42,6 +42,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     private val webView: WebView by lazy { authorizing_payment_webview }
     private val verifier: AuthorizingPaymentURLVerifier by lazy { AuthorizingPaymentURLVerifier(intent) }
     private val uiCustomization: UiCustomization by lazy { intent.getParcelableExtra(EXTRA_UI_CUSTOMIZATION) ?: UiCustomization.default }
+    private var isWebViewSetup = false
 
     private val viewModel: AuthorizingPaymentViewModel by viewModels {
         viewModelFactory ?: AuthorizingPaymentViewModelFactory(
@@ -59,11 +60,17 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         supportActionBar?.title = uiCustomization.uiCustomization.toolbarCustomization?.headerText
             ?: getString(R.string.title_authorizing_payment)
 
-        if (verifier.verifyExternalURL(verifier.authorizedURL)) {
-            openDeepLink(verifier.authorizedURL)
+        val authUrl = verifier.authorizedURLString
+        // check for legacy payments that require web view
+        if (authUrl.endsWith("/pay")) {
+            setupWebView()
+        } else {
+            // Check if the URL needs to be opened externally
+            if (verifier.verifyExternalURL(verifier.authorizedURL)) {
+                openDeepLink(verifier.authorizedURL)
+            }
+            observeData()
         }
-
-        observeData()
     }
 
     @TestOnly
@@ -201,6 +208,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     }
 
     private fun setupWebView() {
+        isWebViewSetup = true
         setupWebViewClient()
         with(webView.settings) {
             javaScriptEnabled = true
@@ -237,7 +245,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     }
 
     private fun finishActivityWithSuccessful(data: Intent?) {
-        setResult(Activity.RESULT_OK, data)
+        setResult(if (isWebViewSetup) AuthorizingPaymentActivity.WEBVIEW_CLOSED_RESULT_CODE else Activity.RESULT_OK, data)
         finish()
     }
 
@@ -261,5 +269,10 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
          * This is an optional parameter. If not provided, the default UI will be used.
          */
         const val EXTRA_UI_CUSTOMIZATION = "OmiseActivity.uiCustomization"
+
+        /**
+         * A new result code that is not in the default Activity values to indicate that the web view has been closed after the authorization url has been opened using web view
+         */
+        const val WEBVIEW_CLOSED_RESULT_CODE = 5
     }
 }


### PR DESCRIPTION
Enable webview for legacy payments that have `/pay` as ending route in auth url
- Additional result code is introduced to allow integrators to determine if the authentication terminated from webview: 
```
const val WEBVIEW_CLOSED_RESULT_CODE = 5
```