### PR TITLE
Fallback to web flow in case Netcetera 3DS SDK fails

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -265,9 +265,9 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         val resultIntent = Intent().apply {
             putExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT, Failure(throwable))
         }
-        if(arrayOf("Challenge protocol error","Challenge runtime error","3DS2 initialization failed").contains(throwable.message)){
+        if (arrayOf("Challenge protocol error","Challenge runtime error","3DS2 initialization failed").contains(throwable.message)) {
             setupWebView()
-        }else{
+        } else {
             setResult(Activity.RESULT_OK, resultIntent)
             finish()
         }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -265,7 +265,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         val resultIntent = Intent().apply {
             putExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT, Failure(throwable))
         }
-        if (arrayOf("Challenge protocol error","Challenge runtime error","3DS2 initialization failed").contains(throwable.message)) {
+        if (arrayOf("Challenge protocol error", "Challenge runtime error", "3DS2 initialization failed").contains(throwable.message)) {
             setupWebView()
         } else {
             setResult(Activity.RESULT_OK, resultIntent)

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -265,7 +265,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         val resultIntent = Intent().apply {
             putExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT, Failure(throwable))
         }
-        if(throwable.message == "3DS2 initialization failed"){
+        if(arrayOf("Challenge protocol error","Challenge runtime error","3DS2 initialization failed").contains(throwable.message)){
             setupWebView()
         }else{
             setResult(Activity.RESULT_OK, resultIntent)

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -265,8 +265,12 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         val resultIntent = Intent().apply {
             putExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT, Failure(throwable))
         }
-        setResult(Activity.RESULT_OK, resultIntent)
-        finish()
+        if(throwable.message == "3DS2 initialization failed"){
+            setupWebView()
+        }else{
+            setResult(Activity.RESULT_OK, resultIntent)
+            finish()
+        }
     }
 
 


### PR DESCRIPTION
In case the Netcetera SDk fails to start/initialize the webview will be used to open the authUrl directly. 