### PR TITLE
Pass params from merchant to sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,10 +478,15 @@ Then in your activity, declare the method that will start this activity as follo
 
 ```kotlin
 private fun showAuthorizingPaymentForm() {
-    val intent = Intent(this, AuthorizingPaymentActivity::class.java)
-    intent.putExtra(AuthorizingPaymentURLVerifier.EXTRA_AUTHORIZED_URLSTRING, AUTHORIZED_URL)
-    intent.putExtra(AuthorizingPaymentURLVerifier.EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, EXPECTED_URL_PATTERNS)
-    startActivityForResult(intent, AUTHORIZING_PAYMENT_REQUEST_CODE)
+    Intent(this, AuthorizingPaymentActivity::class.java).run {
+            putExtra(EXTRA_AUTHORIZED_URLSTRING, authorizeUrl)
+            putExtra(EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, arrayOf(returnUrl))
+            putExtra(
+                EXTRA_THREE_DS_REQUESTOR_APP_URL,
+                "sampleapp://omise.co/authorize_return"
+            )
+            startActivityForResult(this, AUTHORIZING_PAYMENT_REQUEST_CODE)
+        }
 }
 ```
 

--- a/app/src/java/java/co/omise/android/example/CheckoutActivity.java
+++ b/app/src/java/java/co/omise/android/example/CheckoutActivity.java
@@ -42,6 +42,7 @@ import kotlin.text.StringsKt;
 
 import static co.omise.android.AuthorizingPaymentURLVerifier.EXTRA_AUTHORIZED_URLSTRING;
 import static co.omise.android.AuthorizingPaymentURLVerifier.EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS;
+import static co.omise.android.ui.AuthorizingPaymentActivity.EXTRA_THREE_DS_REQUESTOR_APP_URL;
 import static co.omise.android.ui.AuthorizingPaymentActivity.EXTRA_UI_CUSTOMIZATION;
 
 public class CheckoutActivity extends AppCompatActivity {
@@ -204,6 +205,7 @@ public class CheckoutActivity extends AppCompatActivity {
         intent.putExtra(EXTRA_AUTHORIZED_URLSTRING, authorizeUrl);
         intent.putExtra(EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, new String[]{returnUrl});
         intent.putExtra(EXTRA_UI_CUSTOMIZATION, uiCustomization);
+        intent.putExtra(EXTRA_THREE_DS_REQUESTOR_APP_URL, "sampleapp://omise.co/authorize_return");
         startActivityForResult(intent, CheckoutActivity.AUTHORIZING_PAYMENT_REQUEST_CODE);
         return Unit.INSTANCE;
     }

--- a/app/src/kotlin/java/co/omise/android/example/CheckoutActivity.kt
+++ b/app/src/kotlin/java/co/omise/android/example/CheckoutActivity.kt
@@ -24,6 +24,7 @@ import co.omise.android.models.Source
 import co.omise.android.models.Token
 import co.omise.android.ui.AuthorizingPaymentActivity
 import co.omise.android.ui.AuthorizingPaymentActivity.Companion.EXTRA_UI_CUSTOMIZATION
+import co.omise.android.ui.AuthorizingPaymentActivity.Companion.EXTRA_THREE_DS_REQUESTOR_APP_URL
 import co.omise.android.ui.AuthorizingPaymentResult
 import co.omise.android.ui.CreditCardActivity
 import co.omise.android.ui.OmiseActivity
@@ -201,6 +202,10 @@ class CheckoutActivity : AppCompatActivity() {
             putExtra(EXTRA_AUTHORIZED_URLSTRING, authorizeUrl)
             putExtra(EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, arrayOf(returnUrl))
             putExtra(EXTRA_UI_CUSTOMIZATION, uiCustomization)
+            putExtra(
+                EXTRA_THREE_DS_REQUESTOR_APP_URL,
+                "sampleapp://omise.co/authorize_return"
+            )
             startActivityForResult(this, AUTHORIZING_PAYMENT_REQUEST_CODE)
         }
     }
@@ -225,6 +230,13 @@ class CheckoutActivity : AppCompatActivity() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+
+        // custom result code when web view is closed
+        if (resultCode == AuthorizingPaymentActivity.WEBVIEW_CLOSED_RESULT_CODE) {
+            snackbar.setText(R.string.webview_closed).show()
+            return
+        }
+
         if (resultCode == RESULT_CANCELED) {
             snackbar.setText(R.string.payment_cancelled).show()
             return

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:supportsRtl="true"
         android:usesCleartextTraffic="false"
         android:theme="@style/OmiseTheme">
-        <activity android:name=".PaymentResultActivity">
+        <activity android:name=".PaymentResultActivity" android:launchMode="singleTask" android:exported="true">
             <intent-filter android:label="Payment Result">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/java/co/omise/android/example/PaymentResultActivity.kt
+++ b/app/src/main/java/co/omise/android/example/PaymentResultActivity.kt
@@ -1,5 +1,6 @@
 package co.omise.android.example
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.TextView
@@ -19,5 +20,11 @@ class PaymentResultActivity : AppCompatActivity() {
         } ?: run {
             resultText.text = "No result found"
         }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        // Depending on your application status, handle the result from the payment app as needed
     }
 }

--- a/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
@@ -39,6 +39,7 @@ import co.omise.android.OmiseException
 import co.omise.android.R
 import co.omise.android.models.Authentication.AuthenticationStatus
 import co.omise.android.ui.AuthorizingPaymentActivity.Companion.EXTRA_AUTHORIZING_PAYMENT_RESULT
+import co.omise.android.ui.AuthorizingPaymentActivity.Companion.EXTRA_THREE_DS_REQUESTOR_APP_URL
 import co.omise.android.ui.AuthorizingPaymentResult.ThreeDS1Completed
 import co.omise.android.ui.AuthorizingPaymentResult.ThreeDS2Completed
 import co.omise.android.utils.interceptActivityLifecycle
@@ -77,8 +78,10 @@ class AuthorizingPaymentActivityTest {
     private val returnUrl = "http://www.example.com"
     private val deepLinkAuthorizeUrl = "bankapp://omise.co/authorize?return_uri=sampleapp://omise.co/authorize_return?result=success"
     private val deepLinkReturnUrl = "sampleapp://omise.co/authorize_return?result=success"
+    private  val threeDSRequestorAppURL = "sampleapp://omise.co/authorize_return"
     private val intent = Intent(ApplicationProvider.getApplicationContext(), AuthorizingPaymentActivity::class.java).apply {
         putExtra(EXTRA_AUTHORIZED_URLSTRING, authorizeUrl)
+        putExtra(EXTRA_THREE_DS_REQUESTOR_APP_URL, threeDSRequestorAppURL)
         putExtra(EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, arrayOf(returnUrl))
     }
 
@@ -112,6 +115,32 @@ class AuthorizingPaymentActivityTest {
         }
     }
 
+    @Test
+    fun errorWhenThreeDSRequestorAppURLNotSet() {
+        // Create an intent without setting EXTRA_THREE_DS_REQUESTOR_APP_URL
+        val intentWithoutThreeDSRequestorAppURL = Intent(
+            ApplicationProvider.getApplicationContext(),
+            AuthorizingPaymentActivity::class.java
+        ).apply {
+            putExtra(EXTRA_AUTHORIZED_URLSTRING, nonLegacyAuthorizeUrl)
+            putExtra(EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, arrayOf(returnUrl))
+        }
+
+        // Launch the activity
+       val scenario= ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(
+            intentWithoutThreeDSRequestorAppURL
+        )
+        val activityResult = scenario.result
+        // Check if the received error is as expected
+        val expectedError = OmiseException("The threeDSRequestorAppURL must be provided in the intent")
+        activityResult.resultData.setExtrasClassLoader(this::class.java.classLoader)
+        assertEquals(Activity.RESULT_OK, activityResult.resultCode)
+        assertEquals(
+            expectedError.message,
+            activityResult.resultData.getParcelableExtra<AuthorizingPaymentResult.Failure>(EXTRA_AUTHORIZING_PAYMENT_RESULT)?.throwable?.message
+        )
+
+    }
     @Test
     fun fallback3DS1_whenAuthenticationStatusIsChallengeV1ThenLoadAuthorizeUrlToWebView() {
         ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
@@ -328,6 +357,7 @@ class AuthorizingPaymentActivityTest {
     fun openDeepLink_whenPressBackOnExternalAppThenReturnResult() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), AuthorizingPaymentActivity::class.java).apply {
             putExtra(EXTRA_AUTHORIZED_URLSTRING, deepLinkAuthorizeUrl)
+            putExtra(EXTRA_THREE_DS_REQUESTOR_APP_URL, threeDSRequestorAppURL)
             putExtra(EXTRA_EXPECTED_RETURN_URLSTRING_PATTERNS, arrayOf(deepLinkReturnUrl))
         }
         intending(hasData(Uri.parse(deepLinkAuthorizeUrl))).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -43,6 +43,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     private val webView: WebView by lazy { authorizing_payment_webview }
     private val verifier: AuthorizingPaymentURLVerifier by lazy { AuthorizingPaymentURLVerifier(intent) }
     private val uiCustomization: UiCustomization by lazy { intent.getParcelableExtra(EXTRA_UI_CUSTOMIZATION) ?: UiCustomization.default }
+    private lateinit var threeDSRequestorAppURL: String
     private var isWebViewSetup = false
 
     private val viewModel: AuthorizingPaymentViewModel by viewModels {
@@ -50,12 +51,19 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
             activity = this,
             urlVerifier = verifier,
             uiCustomization = uiCustomization,
+            passedThreeDSRequestorAppURL = threeDSRequestorAppURL
         )
     }
     private var viewModelFactory: ViewModelProvider.Factory? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        threeDSRequestorAppURL = intent.getStringExtra(EXTRA_THREE_DS_REQUESTOR_APP_URL)
+            ?: run {
+                finishActivityWithFailure(OmiseException("The threeDSRequestorAppURL must be provided in the intent."))
+                return
+            }
 
         if (intent.getBooleanExtra(OmiseActivity.EXTRA_IS_SECURE, true)) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
@@ -286,5 +294,10 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
          * A new result code that is not in the default Activity values to indicate that the web view has been closed after the authorization url has been opened using web view
          */
         const val WEBVIEW_CLOSED_RESULT_CODE = 5
+
+        /**
+         * The threeDSRequestorAppURL of the host app. This parameter will be used to allow the external app flows to redirect back to the merchant app (OOB flow)
+         */
+        const val EXTRA_THREE_DS_REQUESTOR_APP_URL = "OmiseActivity.threeDSRequestorAppURL"
     }
 }

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -59,18 +59,17 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        threeDSRequestorAppURL = intent.getStringExtra(EXTRA_THREE_DS_REQUESTOR_APP_URL)
-            ?: run {
-                finishActivityWithFailure(OmiseException("The threeDSRequestorAppURL must be provided in the intent."))
-                return
-            }
-
         if (intent.getBooleanExtra(OmiseActivity.EXTRA_IS_SECURE, true)) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
 
         setContentView(R.layout.activity_authorizing_payment)
         setupActionBarTitle()
+        threeDSRequestorAppURL = intent.getStringExtra(EXTRA_THREE_DS_REQUESTOR_APP_URL)
+            ?: run {
+                finishActivityWithFailure(OmiseException("The threeDSRequestorAppURL must be provided in the intent"))
+                return
+            }
         handlePaymentAuthorization()
     }
 

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -28,6 +28,7 @@ internal class AuthorizingPaymentViewModelFactory(
     private val activity: Activity,
     private val urlVerifier: AuthorizingPaymentURLVerifier,
     private val uiCustomization: UiCustomization,
+    private  val passedThreeDSRequestorAppURL: String
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         val client = Client("")
@@ -36,7 +37,7 @@ internal class AuthorizingPaymentViewModelFactory(
             threeDS2Service = ThreeDS2ServiceInstance.get(),
             uiCustomization = uiCustomization.uiCustomization,
         )
-        return AuthorizingPaymentViewModel(client, urlVerifier, wrapper) as T
+        return AuthorizingPaymentViewModel(client, urlVerifier, wrapper,passedThreeDSRequestorAppURL) as T
     }
 }
 
@@ -44,6 +45,7 @@ internal class AuthorizingPaymentViewModel(
     private val client: Client,
     private val urlVerifier: AuthorizingPaymentURLVerifier,
     private val threeDS2Service: ThreeDS2ServiceWrapper,
+    private  val passedThreeDSRequestorAppURL: String,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel(), ChallengeStatusReceiver {
 
@@ -144,6 +146,7 @@ internal class AuthorizingPaymentViewModel(
         val ares = _authenticationResponse.value?.ares ?: return
         val challengeParameters = ChallengeParameters().apply {
             set3DSServerTransactionID(ares.threeDSServerTransID)
+            setThreeDSRequestorAppURL("${passedThreeDSRequestorAppURL}?transID=${ares.sdkTransID}")
             acsTransactionID = ares.acsTransID
             // TODO : check if where to get the sdkReferenceNumber value
             acsRefNumber = BuildConfig.ACS_REF_NUMBER

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -142,11 +142,18 @@ internal class AuthorizingPaymentViewModel(
         }
     }
 
+    internal fun createThreeDSRequestorAppURL(sdkTransID: String?): String {
+        // Check if the URL already contains a query string
+        val separator = if (passedThreeDSRequestorAppURL.contains("?")) "&" else "?"
+        // Append the transaction ID to the URL
+        return "$passedThreeDSRequestorAppURL${separator}transID=${sdkTransID}"
+    }
+
     fun doChallenge(activity: Activity) {
         val ares = _authenticationResponse.value?.ares ?: return
         val challengeParameters = ChallengeParameters().apply {
             set3DSServerTransactionID(ares.threeDSServerTransID)
-            setThreeDSRequestorAppURL("${passedThreeDSRequestorAppURL}?transID=${ares.sdkTransID}")
+            setThreeDSRequestorAppURL(createThreeDSRequestorAppURL(ares.sdkTransID))
             acsTransactionID = ares.acsTransID
             // TODO : check if where to get the sdkReferenceNumber value
             acsRefNumber = BuildConfig.ACS_REF_NUMBER

--- a/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
+++ b/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
@@ -46,6 +46,7 @@ class AuthorizingPaymentViewModelTest {
     private val urlVerifier: AuthorizingPaymentURLVerifier = mock()
     private val threeDS2Service: ThreeDS2ServiceWrapper = mock()
     private val transaction: Transaction = mock()
+    private val threeDSRequestorAppURL = "sampleapp://omise.co/authorize_return"
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -72,7 +73,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun initialize3DS_shouldInitialize3DS2ServiceAndSendAuthenticationRequest() = runTest {
-        AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(threeDS2Service).initialize()
         verify(client).send(any<Request<Authentication>>())
@@ -83,7 +84,7 @@ class AuthorizingPaymentViewModelTest {
         threeDS2Service.stub {
             onBlocking { initialize() } doReturn Result.failure(InvalidInputException("Something went wrong."))
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(threeDS2Service).initialize()
         verify(client, never()).send(any<Request<Authentication>>())
@@ -97,7 +98,7 @@ class AuthorizingPaymentViewModelTest {
                 status = AuthenticationStatus.SUCCESS
             )
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(client).send(any<Request<Authentication>>())
         verify(transaction).close()
@@ -111,7 +112,7 @@ class AuthorizingPaymentViewModelTest {
                 status = AuthenticationStatus.CHALLENGE
             )
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(client).send(any<Request<Authentication>>())
         verify(transaction, never()).close()
@@ -126,7 +127,7 @@ class AuthorizingPaymentViewModelTest {
                 status = AuthenticationStatus.CHALLENGE_V1
             )
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(client).send(any<Request<Authentication>>())
         verify(transaction).close()
@@ -140,7 +141,7 @@ class AuthorizingPaymentViewModelTest {
                 status = AuthenticationStatus.FAILED
             )
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(client).send(any<Request<Authentication>>())
         verify(transaction).close()
@@ -155,7 +156,7 @@ class AuthorizingPaymentViewModelTest {
                 message = "Something went wrong."
             )
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         verify(client).send(any<Request<Authentication>>())
         verify(transaction).close()
@@ -176,7 +177,7 @@ class AuthorizingPaymentViewModelTest {
                 )
             )
         }
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.doChallenge(mock())
 
@@ -198,7 +199,7 @@ class AuthorizingPaymentViewModelTest {
             )
         }
         whenever(threeDS2Service.doChallenge(any(), any(), any(), any())).doThrow(SDKRuntimeException("Something went wrong.", null))
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.doChallenge(mock())
 
@@ -208,7 +209,7 @@ class AuthorizingPaymentViewModelTest {
     @Test
     fun completed_whenReceivedTransactionStatusYThenSetAuthenticatedStatus() {
         val completionEvent = CompletionEvent(UUID.randomUUID().toString(), "Y")
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.completed(completionEvent)
 
@@ -217,7 +218,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun completed_whenReceivedTransactionStatusNThenSetNotAuthenticatedStatus() {
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.completed(CompletionEvent(UUID.randomUUID().toString(), "N"))
 
@@ -226,7 +227,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun completed_whenReceivedUnknownTransactionStatusThenSetError() {
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.completed(CompletionEvent(UUID.randomUUID().toString(), "unknown"))
 
@@ -235,7 +236,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun cancelled_whenReceivedCancelledEventThenSetError() {
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.cancelled()
 
@@ -244,7 +245,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun timedout_whenReceivedTimedoutEventThenSetError() {
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.timedout()
 
@@ -253,7 +254,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun protocolError_whenReceivedProtocolErrorEventThenSetError() {
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.protocolError(
             ProtocolErrorEvent(
@@ -274,7 +275,7 @@ class AuthorizingPaymentViewModelTest {
 
     @Test
     fun runtimeError_whenReceivedRuntimeErrorEventThenSetError() {
-        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
 
         viewModel.runtimeError(
             RuntimeErrorEvent(

--- a/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
+++ b/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
@@ -164,6 +164,25 @@ class AuthorizingPaymentViewModelTest {
     }
 
     @Test
+    fun createThreeDSRequestorAppURL_should_add_transactionId_query_param()= runTest {
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, threeDSRequestorAppURL,testDispatcher)
+        val sdkTransactionId = "123"
+        val updatedUrl = viewModel.createThreeDSRequestorAppURL(sdkTransactionId)
+        val expectedUrl = "$threeDSRequestorAppURL?transID=$sdkTransactionId"
+        assertEquals(updatedUrl,expectedUrl)
+    }
+
+    @Test
+    fun createThreeDSRequestorAppURL_should_not_ignore_already_existing_query_params()= runTest {
+        val urlWithParams = "$threeDSRequestorAppURL?param=value"
+        val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, urlWithParams,testDispatcher)
+        val sdkTransactionId = "123"
+        val updatedUrl = viewModel.createThreeDSRequestorAppURL(sdkTransactionId)
+        val expectedUrl = "$urlWithParams&transID=$sdkTransactionId"
+        assertEquals(updatedUrl,expectedUrl)
+    }
+
+    @Test
     fun doChallenge_shouldExecuteDoChallenge() = runTest {
         client.stub {
             onBlocking { send(any<Request<Authentication>>()) } doReturn Authentication(


### PR DESCRIPTION
Add the ability to pass `threeDSRequestorAppURL` from the merchant app to the SDK using extra intent in the `AuthorizingPaymentActivity` :
```kotlin
putExtra(
                EXTRA_THREE_DS_REQUESTOR_APP_URL,
                "sampleapp://omise.co/authorize_return"
            )
```