### PR TITLE
Replace strings with enums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Run unit tests
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Switch to jacocoTestReport when instrumentation flakiness is fixed
         run: ./gradlew sdk:jacocoUnitTestReport sdk:sonar
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Android CI
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run unit tests
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Switch to jacocoTestReport when instrumentation flakiness is fixed
         run: ./gradlew sdk:jacocoUnitTestReport sdk:sonar
 

--- a/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
@@ -126,7 +126,7 @@ class AuthorizingPaymentActivityTest {
     fun fallbackToWebView_whenOmiseExceptionIsProtocolError() {
         intent.putExtra(EXTRA_AUTHORIZED_URLSTRING, nonLegacyAuthorizeUrl)
         ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
-        val testException = OmiseException("Challenge protocol error")
+        val testException = OmiseException(ChallengeStatus.PROTOCOL_ERROR.value)
         error.postValue(testException)
         onView(withId(R.id.authorizing_payment_webview))
             .check(matches(isDisplayed()))
@@ -140,7 +140,7 @@ class AuthorizingPaymentActivityTest {
     fun fallbackToWebView_whenOmiseExceptionIsChallengeRuntimeError() {
         intent.putExtra(EXTRA_AUTHORIZED_URLSTRING, nonLegacyAuthorizeUrl)
         ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
-        val testException = OmiseException("Challenge runtime error")
+        val testException = OmiseException(ChallengeStatus.RUNTIME_ERROR.value)
         error.postValue(testException)
         onView(withId(R.id.authorizing_payment_webview))
             .check(matches(isDisplayed()))
@@ -154,7 +154,7 @@ class AuthorizingPaymentActivityTest {
     fun fallbackToWebView_whenOmiseExceptionIs3DS2InitializationFailed() {
         intent.putExtra(EXTRA_AUTHORIZED_URLSTRING, nonLegacyAuthorizeUrl)
         ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
-        val testException = OmiseException("3DS2 initialization failed")
+        val testException = OmiseException(OmiseSDKError.THREE_DS2_INITIALIZATION_FAILED.value)
         error.postValue(testException)
         onView(withId(R.id.authorizing_payment_webview))
             .check(matches(isDisplayed()))
@@ -246,7 +246,7 @@ class AuthorizingPaymentActivityTest {
         activityResult.resultData.setExtrasClassLoader(this::class.java.classLoader)
         assertEquals(Activity.RESULT_OK, activityResult.resultCode)
         assertEquals(
-            "Authentication failed.",
+            AuthenticationStatus.FAILED.message,
             (activityResult.resultData.getParcelableExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT) as? AuthorizingPaymentResult.Failure)?.throwable?.message
         )
     }
@@ -254,14 +254,15 @@ class AuthorizingPaymentActivityTest {
     @Test
     fun returnActivityResult_whenHasErrorThenReturnFailureResult() {
         val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
-        val testException = OmiseException("Somethings went wrong.")
+        val randomError = "Somethings went wrong."
+        val testException = OmiseException(randomError)
         error.postValue(testException)
 
         val activityResult = scenario.result
         activityResult.resultData.setExtrasClassLoader(this::class.java.classLoader)
         assertEquals(Activity.RESULT_OK, activityResult.resultCode)
         assertEquals(
-            "Somethings went wrong.",
+            randomError,
             activityResult.resultData.getParcelableExtra<AuthorizingPaymentResult.Failure>(EXTRA_AUTHORIZING_PAYMENT_RESULT)?.throwable?.message
         )
     }

--- a/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/AuthorizingPaymentActivityTest.kt
@@ -254,7 +254,7 @@ class AuthorizingPaymentActivityTest {
     @Test
     fun returnActivityResult_whenHasErrorThenReturnFailureResult() {
         val scenario = ActivityScenario.launchActivityForResult<AuthorizingPaymentActivity>(intent)
-        val randomError = "Somethings went wrong."
+        val randomError = "Somethings went wrong"
         val testException = OmiseException(randomError)
         error.postValue(testException)
 

--- a/sdk/src/main/java/co/omise/android/models/Authentication.kt
+++ b/sdk/src/main/java/co/omise/android/models/Authentication.kt
@@ -25,12 +25,12 @@ internal data class Authentication(
     override val deleted: Boolean = false,
 ) : Model {
 
-    enum class AuthenticationStatus(val value: String) {
+    enum class AuthenticationStatus(val value: String, val message: String? = null) {
         @JsonProperty("success")
         SUCCESS("success"),
 
         @JsonProperty("failed")
-        FAILED("failed"),
+        FAILED("failed","Authentication failed"),
 
         @JsonProperty("challenge_v1")
         CHALLENGE_V1("challenge_v1"),

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -77,7 +77,9 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
                 Authentication.AuthenticationStatus.SUCCESS -> finishActivityWithSuccessful(TransactionStatus.AUTHENTICATED)
                 Authentication.AuthenticationStatus.CHALLENGE_V1 -> setupWebView()
                 Authentication.AuthenticationStatus.CHALLENGE -> viewModel.doChallenge(this)
-                Authentication.AuthenticationStatus.FAILED -> finishActivityWithFailure(OmiseException("Authentication failed."))
+                Authentication.AuthenticationStatus.FAILED -> finishActivityWithFailure(OmiseException(
+                    Authentication.AuthenticationStatus.FAILED.message!!
+                ))
             }
         }
 
@@ -174,7 +176,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
             val externalIntent = Intent(Intent.ACTION_VIEW, uri)
             startActivityForResult(externalIntent, REQUEST_EXTERNAL_CODE)
         } catch (e: ActivityNotFoundException) {
-            finishActivityWithFailure(OmiseException("Open deep-link failed.", e))
+            finishActivityWithFailure(OmiseException(OmiseSDKError.OPEN_DEEP_LINK_FAILED.value, e))
         }
     }
 
@@ -265,7 +267,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         val resultIntent = Intent().apply {
             putExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT, Failure(throwable))
         }
-        if (arrayOf("Challenge protocol error", "Challenge runtime error", "3DS2 initialization failed").contains(throwable.message)) {
+        if (arrayOf(ChallengeStatus.PROTOCOL_ERROR.value, ChallengeStatus.RUNTIME_ERROR.value, OmiseSDKError.THREE_DS2_INITIALIZATION_FAILED.value).contains(throwable.message)) {
             setupWebView()
         } else {
             setResult(Activity.RESULT_OK, resultIntent)

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentActivity.kt
@@ -187,7 +187,7 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
 
     private fun handlePaymentAuthorization() {
         val authUrlString = verifier.authorizedURLString
-        val authUrl=verifier.authorizedURL
+        val authUrl = verifier.authorizedURL
         // check for legacy payments that require web view
         if (authUrlString.endsWith("/pay")) {
             setupWebView()
@@ -267,7 +267,12 @@ class AuthorizingPaymentActivity : AppCompatActivity() {
         val resultIntent = Intent().apply {
             putExtra(EXTRA_AUTHORIZING_PAYMENT_RESULT, Failure(throwable))
         }
-        if (arrayOf(ChallengeStatus.PROTOCOL_ERROR.value, ChallengeStatus.RUNTIME_ERROR.value, OmiseSDKError.THREE_DS2_INITIALIZATION_FAILED.value).contains(throwable.message)) {
+        if (arrayOf(
+                ChallengeStatus.PROTOCOL_ERROR.value,
+                ChallengeStatus.RUNTIME_ERROR.value,
+                OmiseSDKError.THREE_DS2_INITIALIZATION_FAILED.value
+            ).contains(throwable.message)
+        ) {
             setupWebView()
         } else {
             setResult(Activity.RESULT_OK, resultIntent)

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -204,7 +204,7 @@ enum class ChallengeStatus(val value: String) {
 }
 
 enum class OmiseSDKError(val value: String) {
-    OPEN_DEEP_LINK_FAILED("Open deep-link failed"),
+    OPEN_DEEP_LINK_FAILED("Open deep link failed"),
     THREE_DS2_INITIALIZATION_FAILED("3DS2 initialization failed"),
 }
 

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -69,7 +69,7 @@ internal class AuthorizingPaymentViewModel(
         if (e is OmiseException) {
             _error.postValue(e)
         } else {
-            _error.postValue(OmiseException("Authentication failed.", e))
+            _error.postValue(OmiseException(Authentication.AuthenticationStatus.FAILED.message!!, e))
         }
     }
 
@@ -81,7 +81,7 @@ internal class AuthorizingPaymentViewModel(
                         sendAuthenticationRequest()
                     },
                     onFailure = {
-                        _error.postValue(OmiseException("3DS2 initialization failed", it))
+                        _error.postValue(OmiseException(OmiseSDKError.THREE_DS2_INITIALIZATION_FAILED.value, it))
                     }
                 )
             }
@@ -136,7 +136,7 @@ internal class AuthorizingPaymentViewModel(
         } catch (e: Exception) {
             _isLoading.postValue(false)
             transaction.close()
-            _error.postValue(OmiseException("Authentication failed", e))
+            _error.postValue(OmiseException(Authentication.AuthenticationStatus.FAILED.message!!, e))
         }
     }
 
@@ -153,7 +153,7 @@ internal class AuthorizingPaymentViewModel(
         try {
             threeDS2Service.doChallenge(activity, challengeParameters, this, 5)
         } catch (e: Exception) {
-            _error.postValue(OmiseException("Challenge failed", e))
+            _error.postValue(OmiseException(ChallengeStatus.FAILED.value, e))
         }
     }
 
@@ -166,24 +166,45 @@ internal class AuthorizingPaymentViewModel(
         when (event?.transactionStatus) {
             "Y" -> _transactionStatus.postValue(TransactionStatus.AUTHENTICATED)
             "N" -> _transactionStatus.postValue(TransactionStatus.NOT_AUTHENTICATED)
-            else -> _error.postValue(OmiseException("Challenge completed with unknown status: ${event?.transactionStatus}"))
+            else -> _error.postValue(OmiseException(ChallengeStatus.COMPLETED_WITH_UNKNOWN_STATUS.includeUnknownTransactionStatusWithError(event?.transactionStatus)))
         }
     }
 
     override fun cancelled() {
-        _error.postValue(OmiseException("Challenge cancelled"))
+        _error.postValue(OmiseException(ChallengeStatus.CANCELLED.value))
     }
 
     override fun timedout() {
-        _error.postValue(OmiseException("Challenge timedout"))
+        _error.postValue(OmiseException(ChallengeStatus.TIMED_OUT.value))
     }
 
     override fun protocolError(event: com.netcetera.threeds.sdk.api.transaction.challenge.events.ProtocolErrorEvent?) {
-        _error.postValue(OmiseException("Challenge protocol error"))
+        _error.postValue(OmiseException(ChallengeStatus.PROTOCOL_ERROR.value))
     }
 
     override fun runtimeError(event: com.netcetera.threeds.sdk.api.transaction.challenge.events.RuntimeErrorEvent?) {
-        _error.postValue(OmiseException("Challenge runtime error"))
+        _error.postValue(OmiseException(ChallengeStatus.RUNTIME_ERROR.value))
     }
     /** End of [ChallengeStatusReceiver] implementation. */
 }
+
+enum class ChallengeStatus(val value: String) {
+    RUNTIME_ERROR("Challenge runtime error"),
+    PROTOCOL_ERROR("Challenge protocol error"),
+    FAILED("Challenge failed"),
+    TIMED_OUT("Challenge timedout"),
+    CANCELLED("Challenge cancelled"),
+    COMPLETED_WITH_UNKNOWN_STATUS("Challenge completed with unknown status");
+
+
+    // Custom constructor to include the transaction status in the error message when the transaction status is unknown
+    fun includeUnknownTransactionStatusWithError(transactionStatus: String?): String {
+        return "Challenge completed with unknown status: $transactionStatus"
+    }
+}
+
+enum class OmiseSDKError(val value: String) {
+    OPEN_DEEP_LINK_FAILED("Open deep-link failed"),
+    THREE_DS2_INITIALIZATION_FAILED("3DS2 initialization failed"),
+}
+

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -192,7 +192,7 @@ enum class ChallengeStatus(val value: String) {
     RUNTIME_ERROR("Challenge runtime error"),
     PROTOCOL_ERROR("Challenge protocol error"),
     FAILED("Challenge failed"),
-    TIMED_OUT("Challenge timedout"),
+    TIMED_OUT("Challenge timed out"),
     CANCELLED("Challenge cancelled"),
     COMPLETED_WITH_UNKNOWN_STATUS("Challenge completed with unknown status");
 

--- a/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
+++ b/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
@@ -87,7 +87,7 @@ class AuthorizingPaymentViewModelTest {
 
         verify(threeDS2Service).initialize()
         verify(client, never()).send(any<Request<Authentication>>())
-        assertEquals("3DS2 initialization failed", (viewModel.error.value as OmiseException).message)
+        assertEquals(OmiseSDKError.THREE_DS2_INITIALIZATION_FAILED.value, (viewModel.error.value as OmiseException).message)
     }
 
     @Test
@@ -159,7 +159,7 @@ class AuthorizingPaymentViewModelTest {
 
         verify(client).send(any<Request<Authentication>>())
         verify(transaction).close()
-        assertEquals("Authentication failed.", viewModel.error.value?.message)
+        assertEquals(AuthenticationStatus.FAILED.message, viewModel.error.value?.message)
     }
 
     @Test
@@ -202,7 +202,7 @@ class AuthorizingPaymentViewModelTest {
 
         viewModel.doChallenge(mock())
 
-        assertEquals("Challenge failed", (viewModel.error.value as OmiseException).message)
+        assertEquals(ChallengeStatus.FAILED.value, (viewModel.error.value as OmiseException).message)
     }
 
     @Test
@@ -227,10 +227,10 @@ class AuthorizingPaymentViewModelTest {
     @Test
     fun completed_whenReceivedUnknownTransactionStatusThenSetError() {
         val viewModel = AuthorizingPaymentViewModel(client, urlVerifier, threeDS2Service, testDispatcher)
+        val unKnownStatus = "unknown"
+        viewModel.completed(CompletionEvent(UUID.randomUUID().toString(), unKnownStatus))
 
-        viewModel.completed(CompletionEvent(UUID.randomUUID().toString(), "unknown"))
-
-        assertEquals("Challenge completed with unknown status: unknown", (viewModel.error.value as OmiseException).message)
+        assertEquals(ChallengeStatus.COMPLETED_WITH_UNKNOWN_STATUS.includeUnknownTransactionStatusWithError(unKnownStatus), (viewModel.error.value as OmiseException).message)
     }
 
     @Test
@@ -239,7 +239,7 @@ class AuthorizingPaymentViewModelTest {
 
         viewModel.cancelled()
 
-        assertEquals("Challenge cancelled", (viewModel.error.value as OmiseException).message)
+        assertEquals(ChallengeStatus.CANCELLED.value, (viewModel.error.value as OmiseException).message)
     }
 
     @Test
@@ -248,7 +248,7 @@ class AuthorizingPaymentViewModelTest {
 
         viewModel.timedout()
 
-        assertEquals("Challenge timedout", (viewModel.error.value as OmiseException).message)
+        assertEquals(ChallengeStatus.TIMED_OUT.value, (viewModel.error.value as OmiseException).message)
     }
 
     @Test
@@ -269,7 +269,7 @@ class AuthorizingPaymentViewModelTest {
             )
         )
 
-        assertEquals("Challenge protocol error", (viewModel.error.value as OmiseException).message)
+        assertEquals(ChallengeStatus.PROTOCOL_ERROR.value, (viewModel.error.value as OmiseException).message)
     }
 
     @Test
@@ -283,6 +283,6 @@ class AuthorizingPaymentViewModelTest {
             )
         )
 
-        assertEquals("Challenge runtime error", (viewModel.error.value as OmiseException).message)
+        assertEquals(ChallengeStatus.RUNTIME_ERROR.value, (viewModel.error.value as OmiseException).message)
     }
 }


### PR DESCRIPTION
In the current Netcetera POC branch, we raise errors like OmiseException("Authentication failed.", e)) and sometimes like OmiseException("Authentication failed", e) (note presence of period . on first example). 

In [Fallback to web flow in case Netcetera 3DS SDK fails by AnasNaouchi · Pull Request #286 · omise/omise-android](https://github.com/omise/omise-android/pull/286/files)  we do certain actions based on exception raised; the lack of restriction on allowed values will likely lead to bugs.

This PR replaces literal strings with enums where possible.