### PR TITLE
Allign sonar cloud results with PRs and Push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Android CI
 
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Right now, the sonar cloud results for PRs are wrong if the base branch is not master since sonar is not launching on PR.