### PR TITLE
Ignore `stability` field when parsing `item` to json in Atome

### DIFF
--- a/sdk/src/main/java/co/omise/android/models/Item.kt
+++ b/sdk/src/main/java/co/omise/android/models/Item.kt
@@ -1,10 +1,14 @@
 package co.omise.android.models
 
 import android.os.Parcelable
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
+// see https://stackoverflow.com/questions/77639841/a-field-stability-is-added-in-my-parcelable-classes for more info
+// TODO: find a better solution to overcome this issue
+@JsonIgnoreProperties("stability")
 data class Item(
     val sku: String? = null,
     val category: String? = null,


### PR DESCRIPTION
## Description

Atome source api call was failing due to an extra parameter named `stability` being sent in the body request coming from the `Parcelable` class. 

To remove that parameter and make the api call successful we added an ignore annotation to remove the `stability` parameter 

*NOTE:*

- This behavior was not observed on physical devices but it may happen
- This edit was added to avoid breaking the Atome source api call since the api does not accept additional parameters on the item level

### Related links:

Similar issue: https://stackoverflow.com/questions/77639841/a-field-stability-is-added-in-my-parcelable-classes


## Rollback procedure

Re-run the release job for the previous version from github actions and complete the process in nexus repo manager