### PR TITLE
Upgrade targetSDKLevel and compileSDKLevel to 34

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
                     android:scheme="sampleapp" />
             </intent-filter>
         </activity>
-        <activity android:name=".CheckoutActivity">
+        <activity android:name=".CheckoutActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/bankapp/build.gradle
+++ b/bankapp/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'co.omise.android.bankapp'
-    compileSdk 33
+    compileSdk compile_sdk_version
 
     defaultConfig {
         applicationId "co.omise.android.bankapp"
-        minSdk 21
-        targetSdk 33
+        minSdk min_sdk_version
+        targetSdk target_sdk_version
         versionCode 1
         versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,10 @@ buildscript {
         omise_sdk_version = '4.13.1'
         omise_sdk_code_version = 46
 
-        compile_sdk_version = 30
+        compile_sdk_version = 34
         build_tools_version = '29.0.3'
         min_sdk_version = 21
-        target_sdk_version = 30
+        target_sdk_version = 34
 
         omise_threeds_sdk_version = '1.0.0-alpha12'
 

--- a/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.kt
@@ -85,12 +85,12 @@ class CreditCardEditText : OmiseEditText {
         cardBrandImagePaint = Paint(Paint.ANTI_ALIAS_FLAG)
     }
 
-    override fun onDraw(canvas: Canvas?) {
+    override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         cardBrandImage?.let {
             val imageLeftPosition = width.toFloat() - it.width - paddingRight
             val imageTopPosition = (height - it.height) / 2f
-            canvas?.drawBitmap(it, imageLeftPosition, imageTopPosition, cardBrandImagePaint)
+            canvas.drawBitmap(it, imageLeftPosition, imageTopPosition, cardBrandImagePaint)
         }
     }
 

--- a/testsupport/build.gradle
+++ b/testsupport/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-    compileSdkVersion 29
+    compileSdkVersion compile_sdk_version
 
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion min_sdk_version
+        targetSdk target_sdk_version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'


### PR DESCRIPTION
## Description

Upgrade the target sdk and the compile sdk to level 34 as a part of the overall upgrade initiatives.

*NOTE:*

The upgrade was performed on the POC branch as in master we faced some problems:
- Android SDK level 34 required that certain edits for any usage of `PendingIntent` must be performed but this code is not used in the SDK directly but it is part of another library `co.omise:threeds-android` that is no longer used in the SDK but is still a dependency as it is required in some parts of the app like cutom UI in the SDK. Removal of the library was not successful as it is needed for custom UI implementation by the merchant.
- Another attempt was to actually edit the code of the library but complications arose preventing local usage of the library and even if that did not happen we will have to release a new version of a library that is no longer used just to solve this problem.

For that the edits were performed in POC 