### PR TITLE
Set cd jdk back to 11

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '11'
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
## Description

In order to maintain compatibility and ensure that the library has no issues with major java versions, the library in the CI workflow will be compiled using JDK 17 and for publishing the library will be built using jdk 11 as java is backward compatible but users on older java versions may face some issues if they try to run a library compiled using a higher version than what they have locally if the library utilizes some features that are not compatible.  