### PR TITLE
Load intallment terms from capabilities

### DIFF
--- a/app/src/java/java/co/omise/android/example/CheckoutActivity.java
+++ b/app/src/java/java/co/omise/android/example/CheckoutActivity.java
@@ -33,7 +33,6 @@ import co.omise.android.config.ToolbarCustomizationBuilder;
 import co.omise.android.config.UiCustomization;
 import co.omise.android.config.UiCustomizationBuilder;
 import co.omise.android.models.Amount;
-import co.omise.android.models.Capability;
 import co.omise.android.models.Source;
 import co.omise.android.models.Token;
 import co.omise.android.ui.AuthorizingPaymentActivity;
@@ -63,8 +62,6 @@ public class CheckoutActivity extends AppCompatActivity {
     private EditText amountEdit;
     private EditText currencyEdit;
     private Snackbar snackbar;
-
-    private Capability capability;
 
     private ActivityResultLauncher<Intent> authorizingPaymentLauncher;
     private ActivityResultLauncher<Intent> paymentCreatorLauncher;
@@ -97,28 +94,10 @@ public class CheckoutActivity extends AppCompatActivity {
         creditCardButton.setOnClickListener(view -> payByCreditCard());
         authorizeUrlButton.setOnClickListener(view -> AuthorizingPaymentDialog.showAuthorizingPaymentDialog(this, this::startAuthoringPaymentActivity));
 
-        Client client = new Client(PUBLIC_KEY);
-        Request<Capability> request = new Capability.GetCapabilitiesRequestBuilder().build();
-        client.send(request, new RequestListener<Capability>() {
-            @Override
-            public void onRequestSucceed(@NotNull Capability model) {
-                capability = model;
-            }
-
-            @Override
-            public void onRequestFailed(@NotNull Throwable throwable) {
-                snackbar.setText(Objects.requireNonNull(capitalize(throwable.getMessage()))).show();
-            }
-        });
     }
 
     private void choosePaymentMethod() {
         boolean isUsedSpecificsPaymentMethods = PaymentSetting.isUsedSpecificsPaymentMethods(this);
-
-        if (!isUsedSpecificsPaymentMethods && capability == null) {
-            snackbar.setText(R.string.error_capability_have_not_set_yet);
-            return;
-        }
 
         double localAmount = Double.parseDouble(amountEdit.getText().toString().trim());
         String currency = currencyEdit.getText().toString().trim().toLowerCase();
@@ -137,8 +116,6 @@ public class CheckoutActivity extends AppCompatActivity {
 
         if (isUsedSpecificsPaymentMethods) {
             intent.putExtra(OmiseActivity.EXTRA_CAPABILITY, PaymentSetting.createCapabilityFromPreferences(this));
-        } else {
-            intent.putExtra(OmiseActivity.EXTRA_CAPABILITY, capability);
         }
 
         paymentCreatorLauncher.launch(intent);

--- a/app/src/kotlin/java/co/omise/android/example/CheckoutActivity.kt
+++ b/app/src/kotlin/java/co/omise/android/example/CheckoutActivity.kt
@@ -25,9 +25,7 @@ import co.omise.android.config.TextBoxCustomizationBuilder
 import co.omise.android.config.ThemeConfig
 import co.omise.android.config.ToolbarCustomizationBuilder
 import co.omise.android.config.UiCustomizationBuilder
-import co.omise.android.extensions.capitalizeFirstChar
 import co.omise.android.models.Amount
-import co.omise.android.models.Capability
 import co.omise.android.models.Source
 import co.omise.android.models.Token
 import co.omise.android.ui.AuthorizingPaymentActivity
@@ -74,8 +72,6 @@ class CheckoutActivity : AppCompatActivity() {
     private val snackbar: Snackbar by lazy {
         Snackbar.make(findViewById(R.id.content), "", Snackbar.LENGTH_SHORT)
     }
-
-    private var capability: Capability? = null
 
     private lateinit var authorizingPaymentLauncher: ActivityResultLauncher<Intent>
     private lateinit var paymentCreatorLauncher: ActivityResultLauncher<Intent>
@@ -125,27 +121,10 @@ class CheckoutActivity : AppCompatActivity() {
             }
         }
 
-
-        val client = Client(PUBLIC_KEY)
-        val request = Capability.GetCapabilitiesRequestBuilder().build()
-        client.send(request, object : RequestListener<Capability> {
-            override fun onRequestSucceed(model: Capability) {
-                capability = model
-            }
-
-            override fun onRequestFailed(throwable: Throwable) {
-                snackbar.setText(throwable.message?.capitalizeFirstChar().orEmpty()).show()
-            }
-        })
     }
 
     private fun choosePaymentMethod() {
         val isUsedSpecificsPaymentMethods = PaymentSetting.isUsedSpecificsPaymentMethods(this)
-
-        if (!isUsedSpecificsPaymentMethods && capability == null) {
-            snackbar.setText(getString(R.string.error_capability_have_not_set_yet))
-            return
-        }
 
         val localAmount = amountEdit.text.toString().trim().toDouble()
         val currency = currencyEdit.text.toString().trim().lowercase()
@@ -161,8 +140,6 @@ class CheckoutActivity : AppCompatActivity() {
 
             if (isUsedSpecificsPaymentMethods) {
                 putExtra(OmiseActivity.EXTRA_CAPABILITY, PaymentSetting.createCapabilityFromPreferences(this@CheckoutActivity))
-            } else {
-                putExtra(OmiseActivity.EXTRA_CAPABILITY, capability)
             }
 
             paymentCreatorLauncher.launch(this)

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -219,8 +219,7 @@ repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
 }
-// Use locally to generate full report
-// TODO: Fix flaky tests so that this can be used in CI to reflect full coverage
+// Unit and instrumented test
 tasks.create(name: 'jacocoTestReport', type: JacocoReport, dependsOn: ['testProductionDebugUnitTest', 'lint', 'createProductionDebugCoverageReport']) {
     reports {
         xml.required = true
@@ -249,7 +248,7 @@ tasks.create(name: 'jacocoTestReport', type: JacocoReport, dependsOn: ['testProd
             '**/*.ec'
     ])
 }
-// Use in CI to coverage generate report without instrumentation testing
+// Unit tests only
 tasks.create(name: 'jacocoUnitTestReport', type: JacocoReport, dependsOn: ['compileProductionDebugAndroidTestJavaWithJavac','generateProductionDebugAndroidTestBuildConfig','checkProductionDebugAndroidTestAarMetadata','mergeProductionDebugAndroidTestResources','processProductionDebugAndroidTestManifest','testProductionDebugUnitTest', 'lint']) {
     reports {
         xml.required = true

--- a/sdk/src/androidTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -1,35 +1,63 @@
 package co.omise.android.ui
 
+import android.app.Activity
 import android.app.Activity.RESULT_OK
+import android.app.Application
 import android.content.Intent
+import android.os.Bundle
+import android.util.Log
 import android.view.WindowManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import co.omise.android.R
+import co.omise.android.api.Client
+import co.omise.android.api.Request
+import co.omise.android.api.RequestListener
 import co.omise.android.models.Capability
+import co.omise.android.models.PaymentMethod
+import co.omise.android.models.SourceType
 import co.omise.android.models.Token
+import co.omise.android.models.TokenizationMethod
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_TOKEN
+import co.omise.android.utils.itemCount
+import co.omise.android.utils.withListId
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class PaymentCreatorActivityTest {
     @get:Rule
     val intentRule = IntentsRule()
-
-    private val capability = Capability()
+   // capabilities requested by the merchant
+    private val capability = Capability.create(
+        allowCreditCard = true,
+        sourceTypes = listOf(SourceType.Fpx(), SourceType.TrueMoney),
+        tokenizationMethods = listOf(TokenizationMethod.GooglePay)
+    )
+    private val mockClient: Client = mock()
     private val intent =
         Intent(
             ApplicationProvider.getApplicationContext(),
@@ -40,7 +68,49 @@ class PaymentCreatorActivityTest {
             putExtra(OmiseActivity.EXTRA_CURRENCY, "thb")
             putExtra(OmiseActivity.EXTRA_CAPABILITY, capability)
         }
+    private val application = (InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application)
+    private val activityLifecycleCallbacks =
+        object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityCreated(
+                activity: Activity,
+                savedInstanceState: Bundle?,
+            ) {
+                (activity as? PaymentCreatorActivity)?.setClient(mockClient)
+            }
 
+            override fun onActivityStarted(activity: Activity) {}
+
+            override fun onActivityResumed(activity: Activity) {}
+
+            override fun onActivityPaused(activity: Activity) {}
+
+            override fun onActivityStopped(activity: Activity) {}
+
+            override fun onActivitySaveInstanceState(
+                activity: Activity,
+                outState: Bundle,
+            ) {}
+
+            override fun onActivityDestroyed(activity: Activity) {}
+        }
+    @Before
+    fun setUp() {
+        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        whenever(mockClient.send(any<Request<Capability>>(), any())).doAnswer { invocation ->
+            val callback = invocation.getArgument<RequestListener<Capability>>(1)
+            // Capabilities retrieved from api
+            callback.onRequestSucceed(Capability.create(
+                allowCreditCard = true,
+                sourceTypes = listOf(SourceType.TrueMoney,SourceType.PromptPay),
+                tokenizationMethods = listOf(TokenizationMethod.GooglePay,TokenizationMethod.Card)
+            ))
+        }
+    }
+    @After
+    fun tearDown() {
+        reset(mockClient)
+        application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+    }
     @Test
     fun initialActivity_collectExtrasIntent() {
         ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
@@ -58,6 +128,28 @@ class PaymentCreatorActivityTest {
         activity?.navigation?.navigateToCreditCardForm()
 
         intended(hasComponent(hasClassName(CreditCardActivity::class.java.name)))
+    }
+    @Test
+    fun shouldShowOnlyPaymentMethodsRequestedByMerchantAndAvailableInCapability() {
+
+        ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
+
+        onView(
+            withListId(R.id.recycler_view).atPosition(0),
+        ).check(matches(ViewMatchers.isEnabled()))
+            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.payment_method_credit_card_title))))
+        onView(
+            withListId(R.id.recycler_view).atPosition(1),
+        ).check(matches(ViewMatchers.isEnabled()))
+            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.googlepay))))
+        onView(
+            withListId(R.id.recycler_view).atPosition(2),
+        ).check(matches(ViewMatchers.isEnabled()))
+            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.payment_truemoney_title))))
+        onView(ViewMatchers.withText(R.string.payment_method_fpx_title)).check(doesNotExist())
+        onView(withId(R.id.recycler_view))
+            .check(matches(itemCount(3)))
+
     }
 
     @Test

--- a/sdk/src/androidTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -5,12 +5,10 @@ import android.app.Activity.RESULT_OK
 import android.app.Application
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.WindowManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents.intended
@@ -27,7 +25,6 @@ import co.omise.android.api.Client
 import co.omise.android.api.Request
 import co.omise.android.api.RequestListener
 import co.omise.android.models.Capability
-import co.omise.android.models.PaymentMethod
 import co.omise.android.models.SourceType
 import co.omise.android.models.Token
 import co.omise.android.models.TokenizationMethod
@@ -51,12 +48,14 @@ import org.mockito.kotlin.whenever
 class PaymentCreatorActivityTest {
     @get:Rule
     val intentRule = IntentsRule()
-   // capabilities requested by the merchant
-    private val capability = Capability.create(
-        allowCreditCard = true,
-        sourceTypes = listOf(SourceType.Fpx(), SourceType.TrueMoney),
-        tokenizationMethods = listOf(TokenizationMethod.GooglePay)
-    )
+
+    // capabilities requested by the merchant
+    private val capability =
+        Capability.create(
+            allowCreditCard = true,
+            sourceTypes = listOf(SourceType.Fpx(), SourceType.TrueMoney),
+            tokenizationMethods = listOf(TokenizationMethod.GooglePay),
+        )
     private val mockClient: Client = mock()
     private val intent =
         Intent(
@@ -93,24 +92,29 @@ class PaymentCreatorActivityTest {
 
             override fun onActivityDestroyed(activity: Activity) {}
         }
+
     @Before
     fun setUp() {
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
         whenever(mockClient.send(any<Request<Capability>>(), any())).doAnswer { invocation ->
             val callback = invocation.getArgument<RequestListener<Capability>>(1)
             // Capabilities retrieved from api
-            callback.onRequestSucceed(Capability.create(
-                allowCreditCard = true,
-                sourceTypes = listOf(SourceType.TrueMoney,SourceType.PromptPay),
-                tokenizationMethods = listOf(TokenizationMethod.GooglePay,TokenizationMethod.Card)
-            ))
+            callback.onRequestSucceed(
+                Capability.create(
+                    allowCreditCard = true,
+                    sourceTypes = listOf(SourceType.TrueMoney, SourceType.PromptPay),
+                    tokenizationMethods = listOf(TokenizationMethod.GooglePay, TokenizationMethod.Card),
+                ),
+            )
         }
     }
+
     @After
     fun tearDown() {
         reset(mockClient)
         application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
     }
+
     @Test
     fun initialActivity_collectExtrasIntent() {
         ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
@@ -129,9 +133,9 @@ class PaymentCreatorActivityTest {
 
         intended(hasComponent(hasClassName(CreditCardActivity::class.java.name)))
     }
+
     @Test
     fun shouldShowOnlyPaymentMethodsRequestedByMerchantAndAvailableInCapability() {
-
         ActivityScenario.launchActivityForResult<PaymentCreatorActivity>(intent)
 
         onView(
@@ -149,7 +153,6 @@ class PaymentCreatorActivityTest {
         onView(ViewMatchers.withText(R.string.payment_method_fpx_title)).check(doesNotExist())
         onView(withId(R.id.recycler_view))
             .check(matches(itemCount(3)))
-
     }
 
     @Test

--- a/sdk/src/main/java/co/omise/android/extensions/IntentExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/IntentExtensions.kt
@@ -14,3 +14,12 @@ internal inline fun <reified T : Parcelable> Intent.parcelable(key: String?): T?
             getParcelableExtra(key)
                 as? T
     }
+internal inline fun <reified T : Parcelable?> Intent.parcelableNullable(key: String?): T? =
+    when {
+        // https://stackoverflow.com/questions/72571804/getserializableextra-and-getparcelableextra-are-deprecated-what-is-the-alternat/73543350#73543350
+        SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableExtra(key, T::class.java)
+        else ->
+            @Suppress("DEPRECATION")
+            getParcelableExtra(key)
+                    as? T
+    }

--- a/sdk/src/main/java/co/omise/android/extensions/IntentExtensions.kt
+++ b/sdk/src/main/java/co/omise/android/extensions/IntentExtensions.kt
@@ -14,6 +14,7 @@ internal inline fun <reified T : Parcelable> Intent.parcelable(key: String?): T?
             getParcelableExtra(key)
                 as? T
     }
+
 internal inline fun <reified T : Parcelable?> Intent.parcelableNullable(key: String?): T? =
     when {
         // https://stackoverflow.com/questions/72571804/getserializableextra-and-getparcelableextra-are-deprecated-what-is-the-alternat/73543350#73543350
@@ -21,5 +22,5 @@ internal inline fun <reified T : Parcelable?> Intent.parcelableNullable(key: Str
         else ->
             @Suppress("DEPRECATION")
             getParcelableExtra(key)
-                    as? T
+                as? T
     }

--- a/sdk/src/main/java/co/omise/android/models/Capability.kt
+++ b/sdk/src/main/java/co/omise/android/models/Capability.kt
@@ -22,7 +22,7 @@ data class Capability(
     @field:JsonProperty("tokenization_methods")
     var tokenizationMethods: List<String>? = null,
     @field:JsonProperty("zero_interest_installments")
-    val zeroInterestInstallments: Boolean = false,
+    var zeroInterestInstallments: Boolean = false,
     @field:JsonProperty("limits")
     var limits: Limits? = null,
     @field:JsonProperty

--- a/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
+++ b/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
@@ -35,7 +35,8 @@ data class PaymentMethod(
         fun createSourceTypeMethod(sourceType: SourceType): PaymentMethod =
             PaymentMethod(
                 name = sourceType.name,
-                installmentTerms = listOf(), // empty list as it will be replaced by the actual terms from capability
+                // empty list as it will be replaced by the actual terms from capability
+                installmentTerms = listOf(),
                 banks =
                     when (sourceType) {
                         is SourceType.Fpx -> sourceType.banks

--- a/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
+++ b/sdk/src/main/java/co/omise/android/models/PaymentMethod.kt
@@ -35,11 +35,7 @@ data class PaymentMethod(
         fun createSourceTypeMethod(sourceType: SourceType): PaymentMethod =
             PaymentMethod(
                 name = sourceType.name,
-                installmentTerms =
-                    when (sourceType) {
-                        is SourceType.Installment -> SourceType.Installment.availableTerms(sourceType)
-                        else -> null
-                    },
+                installmentTerms = listOf(), // empty list as it will be replaced by the actual terms from capability
                 banks =
                     when (sourceType) {
                         is SourceType.Fpx -> sourceType.banks

--- a/sdk/src/main/java/co/omise/android/models/SourceType.kt
+++ b/sdk/src/main/java/co/omise/android/models/SourceType.kt
@@ -140,29 +140,6 @@ sealed class SourceType(
         data class Unknown(
             @JsonValue override val name: String?,
         ) : Installment(name)
-
-        companion object {
-            fun availableTerms(installment: Installment): List<Int> =
-                when (installment) {
-                    Bay -> listOf(3, 4, 6, 9, 10)
-                    BayWlb -> listOf(3, 4, 6, 9, 10)
-                    FirstChoice -> listOf(3, 4, 6, 9, 10, 12, 18, 24, 36)
-                    FirstChoiceWlb -> listOf(3, 4, 6, 9, 10, 12, 18, 24, 36)
-                    Bbl -> listOf(4, 6, 8, 9, 10)
-                    BblWlb -> listOf(4, 6, 8, 9, 10)
-                    Mbb -> listOf(6, 12, 18, 24)
-                    Ktc -> listOf(3, 4, 5, 6, 7, 8, 9, 10)
-                    KtcWlb -> listOf(3, 4, 5, 6, 7, 8, 9, 10)
-                    KBank -> listOf(3, 4, 6, 10)
-                    KBankWlb -> listOf(3, 4, 6, 10)
-                    Scb -> listOf(3, 4, 6, 9, 10)
-                    ScbWlb -> listOf(3, 4, 6, 9, 10)
-                    Ttb -> listOf(3, 4, 6, 10)
-                    TtbWlb -> listOf(3, 4, 6, 10)
-                    Uob -> listOf(3, 4, 6, 10)
-                    is Unknown -> emptyList()
-                }
-        }
     }
 
     companion object {

--- a/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentChooserFragment.kt
@@ -73,7 +73,7 @@ internal class PaymentChooserFragment : OmiseListFragment<PaymentMethodResource>
             -> item.sourceType?.let(::sendRequest)
             PaymentMethodResource.Fpx -> navigation.navigateToFpxEmailForm()
             PaymentMethodResource.GooglePay -> navigation.navigateToGooglePayForm()
-            PaymentMethodResource.DuitNowOBW -> navigation.navigateToDuitNowOBWBankChooser()
+            PaymentMethodResource.DuitNowOBW -> navigation.navigateToDuitNowOBWBankChooser(capability)
             PaymentMethodResource.Atome -> navigation.navigateToAtomeForm()
         }
     }

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -226,14 +226,14 @@ class PaymentCreatorActivity : OmiseActivity() {
             val selectedTokenizationMethods = merchantPassedCapabilities.tokenizationMethods
             if (selectedPaymentMethods != null) {
                 filteredPaymentMethods =
-                    capability.paymentMethods!!.filter { capMethod ->
+                    capability.paymentMethods?.filter { capMethod ->
                         selectedPaymentMethods.map { it.name }.contains(capMethod.name)
                     }
-                capability.paymentMethods = filteredPaymentMethods.toMutableList()
+                capability.paymentMethods = filteredPaymentMethods?.toMutableList()
             }
             if (selectedTokenizationMethods != null) {
                 filteredTokenizationMethods =
-                    capability.tokenizationMethods!!.filter {
+                    capability.tokenizationMethods?.filter {
                         selectedTokenizationMethods.contains(it)
                     }
                 capability.tokenizationMethods = filteredTokenizationMethods

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -143,7 +143,7 @@ class PaymentCreatorActivity : OmiseActivity() {
                 override fun onRequestFailed(throwable: Throwable) {
                     progressBar.visibility = ProgressBar.GONE
                     // Show the error message
-                    errorMessage.text = "Unable to load payment methods"
+                    errorMessage.text = getString(R.string.error_loading_payment_methods)
                     errorMessage.visibility = TextView.VISIBLE
                 }
             },

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -3,7 +3,11 @@ package co.omise.android.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.view.WindowManager
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
@@ -13,12 +17,14 @@ import co.omise.android.api.Request
 import co.omise.android.api.RequestListener
 import co.omise.android.extensions.getMessageFromResources
 import co.omise.android.extensions.parcelable
+import co.omise.android.extensions.parcelableNullable
 import co.omise.android.models.APIError
 import co.omise.android.models.Bank
 import co.omise.android.models.Capability
 import co.omise.android.models.Model
 import co.omise.android.models.PaymentMethod
 import co.omise.android.models.Source
+import co.omise.android.models.SourceType
 import co.omise.android.models.SupportedEcontext
 import co.omise.android.models.Token
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_AMOUNT
@@ -32,6 +38,7 @@ import co.omise.android.ui.OmiseActivity.Companion.EXTRA_PKEY
 import co.omise.android.ui.OmiseActivity.Companion.EXTRA_SOURCE_OBJECT
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_payment_creator.payment_creator_container
+import org.jetbrains.annotations.TestOnly
 import java.io.IOError
 
 /**
@@ -49,28 +56,19 @@ class PaymentCreatorActivity : OmiseActivity() {
     private var googlepayRequestPhoneNumber: Boolean = false
     private val snackbar: Snackbar by lazy { Snackbar.make(payment_creator_container, "", Snackbar.LENGTH_SHORT) }
 
-    private val client: Client by lazy { Client(pkey) }
-
-    private val requester: PaymentCreatorRequester<Source> by lazy {
-        PaymentCreatorRequesterImpl(client, amount, currency, capability)
+    private lateinit var client: Client
+    @TestOnly
+    fun setClient(client: Client) {
+        this.client = client
     }
+
+    private lateinit var requester: PaymentCreatorRequester<Source>
 
     @VisibleForTesting
-    val navigation: PaymentCreatorNavigation by lazy {
-        PaymentCreatorNavigationImpl(
-            this,
-            pkey,
-            amount,
-            currency,
-            cardBrands,
-            googlepayMerchantId,
-            googlepayRequestBillingAddress,
-            googlepayRequestPhoneNumber,
-            REQUEST_CREDIT_CARD,
-            requester,
-            capability,
-        )
-    }
+    lateinit var navigation: PaymentCreatorNavigation
+
+    private lateinit var progressBar: ProgressBar
+    private lateinit var errorMessage: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -80,6 +78,13 @@ class PaymentCreatorActivity : OmiseActivity() {
 
         setContentView(R.layout.activity_payment_creator)
 
+        progressBar = findViewById(R.id.progressBar)
+        errorMessage = findViewById(R.id.errorMessage)
+        // Initially hide the ProgressBar and error message
+        progressBar.visibility = ProgressBar.GONE
+        errorMessage.visibility = TextView.GONE
+
+        title = getString(R.string.payment_chooser_title)
         val onBackPressedCallback =
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
@@ -93,7 +98,84 @@ class PaymentCreatorActivity : OmiseActivity() {
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
         initialize()
 
-        navigation.navigateToPaymentChooser(capability)
+        loadCapability()
+    }
+    // Set the menu button to close the view by the user
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        if(supportFragmentManager.findFragmentById(R.id.payment_creator_container) !is PaymentChooserFragment){
+            menuInflater.inflate(R.menu.menu_toolbar, menu)
+            return true
+        }
+        return  false
+    }
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.close_menu -> {
+                setResult(Activity.RESULT_CANCELED)
+                finish()
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun loadCapability() {
+        // Start loading
+        progressBar.visibility = ProgressBar.VISIBLE
+        // Hide error message
+        errorMessage.visibility = TextView.GONE
+        // Get capability
+        val capabilityRequest = Capability.GetCapabilitiesRequestBuilder().build()
+        client.send(capabilityRequest, object : RequestListener<Capability> {
+            override fun onRequestSucceed(model: Capability) {
+
+                updateActivityWithCapability(model)
+                // Invalidate the options menu to trigger a refresh and hide the menu button
+                // as new button will come from the next view
+                invalidateOptionsMenu()
+                // Hide loading
+                progressBar.visibility = ProgressBar.GONE
+            }
+
+            override fun onRequestFailed(throwable: Throwable) {
+                progressBar.visibility = ProgressBar.GONE
+                // Show the error message
+                errorMessage.text = "Unable to load payment methods"
+                errorMessage.visibility = TextView.VISIBLE
+            }
+        })
+    }
+
+    // Detect if the current activity is still active
+    private fun isActivityActive(): Boolean {
+        return !isFinishing && !isDestroyed
+    }
+
+    private fun updateActivityWithCapability(newCapability: Capability) {
+        capability = newCapability
+        requester = PaymentCreatorRequesterImpl(client, amount, currency, newCapability)
+        requester.capability = newCapability
+        navigation = PaymentCreatorNavigationImpl(
+            this,
+            pkey,
+            amount,
+            currency,
+            cardBrands,
+            googlepayMerchantId,
+            googlepayRequestBillingAddress,
+            googlepayRequestPhoneNumber,
+            REQUEST_CREDIT_CARD,
+            requester,
+            newCapability,
+        )
+        capability = filterCapabilities(newCapability)
+
+        // Replace the capability passed from merchant by the new capability
+        intent.putExtra(EXTRA_CAPABILITY, capability)
+        // Open the payment method chooser if the activity is still active
+        if(isActivityActive()){
+            navigation.navigateToPaymentChooser(capability)
+        }
+
 
         requester.listener =
             object : PaymentCreatorRequestListener {
@@ -116,7 +198,6 @@ class PaymentCreatorActivity : OmiseActivity() {
                     }
                 }
             }
-
         supportFragmentManager.addOnBackStackChangedListener {
             supportActionBar?.let {
                 if (supportFragmentManager.findFragmentById(R.id.payment_creator_container) is PaymentChooserFragment) {
@@ -128,6 +209,41 @@ class PaymentCreatorActivity : OmiseActivity() {
                 }
             }
         }
+    }
+    // Filter the capabilities based on the merchant request and what is available in the capabilities of the merchant account
+    private fun filterCapabilities(capability:Capability):Capability{
+        val merchantPassedCapabilities = intent.parcelableNullable<Capability?>(EXTRA_CAPABILITY)
+        var filteredPaymentMethods : List<PaymentMethod>? = null
+        var filteredTokenizationMethods : List<String>? = null
+
+        if(merchantPassedCapabilities != null){
+            val selectedPaymentMethods = merchantPassedCapabilities.paymentMethods
+            val selectedTokenizationMethods = merchantPassedCapabilities.tokenizationMethods
+            if(selectedPaymentMethods != null){
+
+                filteredPaymentMethods = capability.paymentMethods!!.filter {capMethod->
+                    selectedPaymentMethods.map { it.name }.contains(capMethod.name)
+                }
+                capability.paymentMethods = filteredPaymentMethods.toMutableList()
+            }
+            if(selectedTokenizationMethods != null){
+                filteredTokenizationMethods= capability.tokenizationMethods!!.filter {
+                    selectedTokenizationMethods.contains(it)
+                }
+                capability.tokenizationMethods = filteredTokenizationMethods
+            }
+            capability.zeroInterestInstallments = merchantPassedCapabilities.zeroInterestInstallments
+            // add the tokenization methods into payment methods since the SDK only shows paymentMethods
+            val combinedMethods = capability.paymentMethods?.toMutableList()
+            capability.tokenizationMethods?.forEach { method->
+                run {
+                    combinedMethods?.add(PaymentMethod(method))
+                }
+            }
+            capability.paymentMethods = combinedMethods
+
+        }
+        return  capability
     }
 
     // TODO: find a way to unit test ActivityResult launcher in order to be able to move from deprecated onActivityResult
@@ -165,15 +281,15 @@ class PaymentCreatorActivity : OmiseActivity() {
     }
 
     private fun initialize() {
-        listOf(EXTRA_PKEY, EXTRA_AMOUNT, EXTRA_CURRENCY, EXTRA_CAPABILITY).forEach {
+        listOf(EXTRA_PKEY, EXTRA_AMOUNT, EXTRA_CURRENCY).forEach {
             require(intent.hasExtra(it)) { "Could not found $it." }
         }
         pkey = requireNotNull(intent.getStringExtra(EXTRA_PKEY)) { "${::EXTRA_PKEY.name} must not be null." }
+        if (!this::client.isInitialized) {
+            client = Client(pkey)
+        }
         amount = intent.getLongExtra(EXTRA_AMOUNT, 0)
         currency = requireNotNull(intent.getStringExtra(EXTRA_CURRENCY)) { "${::EXTRA_CURRENCY.name} must not be null." }
-        capability = requireNotNull(intent.parcelable(EXTRA_CAPABILITY)) { "${::EXTRA_CAPABILITY.name} must not be null." }
-        val fetchBrands: List<String>? = capability.paymentMethods?.find { it.name == "card" }?.cardBrands
-        cardBrands = if (fetchBrands != null) fetchBrands as ArrayList<String> else arrayListOf()
         googlepayMerchantId = intent.getStringExtra(EXTRA_GOOGLEPAY_MERCHANT_ID) ?: "[GOOGLEPAY_MERCHANT_ID]"
         googlepayRequestBillingAddress = intent.getBooleanExtra(EXTRA_GOOGLEPAY_REQUEST_BILLING_ADDRESS, false)
         googlepayRequestPhoneNumber = intent.getBooleanExtra(EXTRA_GOOGLEPAY_REQUEST_PHONE_NUMBER, false)
@@ -218,7 +334,7 @@ interface PaymentCreatorNavigation {
 
     fun navigateToGooglePayForm()
 
-    fun navigateToDuitNowOBWBankChooser()
+    fun navigateToDuitNowOBWBankChooser(capability: Capability)
 }
 
 private class PaymentCreatorNavigationImpl(
@@ -366,32 +482,8 @@ private class PaymentCreatorNavigationImpl(
         activity.startActivityForResult(intent, requestCode)
     }
 
-    override fun navigateToDuitNowOBWBankChooser() {
-        /**
-         *  DuitNow OBW didn't support capability api for banks list
-         *  so need to define local banks list
-         */
-        val banks =
-            listOf(
-                Bank(name = "Affin Bank", code = "affin", active = true),
-                Bank(name = "Alliance Bank (Personal)", code = "alliance", active = true),
-                Bank(name = "AGRONet", code = "agro", active = true),
-                Bank(name = "AmBank", code = "ambank", active = true),
-                Bank(name = "Bank Islam", code = "islam", active = true),
-                Bank(name = "Bank Muamalat", code = "muamalat", active = true),
-                Bank(name = "Bank Rakyat", code = "rakyat", active = true),
-                Bank(name = "BSN", code = "bsn", active = true),
-                Bank(name = "CIMB Clicks", code = "cimb", active = true),
-                Bank(name = "Hong Leong Bank", code = "hongleong", active = true),
-                Bank(name = "HSBC Bank", code = "hsbc", active = true),
-                Bank(name = "KFH", code = "kfh", active = true),
-                Bank(name = "Maybank2U", code = "maybank2u", active = true),
-                Bank(name = "OCBC Bank", code = "ocbc", active = true),
-                Bank(name = "Public Bank", code = "public", active = true),
-                Bank(name = "RHB Bank", code = "rhb", active = true),
-                Bank(name = "Standard Chartered", code = "sc", active = true),
-                Bank(name = "UOB Bank", code = "uob", active = true),
-            )
+    override fun navigateToDuitNowOBWBankChooser(capability: Capability) {
+       val banks = capability.paymentMethods?.find { it.name == SourceType.DuitNowOBW.name }?.banks?: emptyList()
 
         val fragment =
             DuitNowOBWBankChooserFragment.newInstance(banks).apply {
@@ -405,7 +497,7 @@ private class PaymentCreatorNavigationImpl(
 interface PaymentCreatorRequester<T : Model> {
     val amount: Long
     val currency: String
-    val capability: Capability
+    var capability: Capability
 
     fun request(
         request: Request<T>,
@@ -423,7 +515,7 @@ private class PaymentCreatorRequesterImpl(
     private val client: Client,
     override val amount: Long,
     override val currency: String,
-    override val capability: Capability,
+    override var capability: Capability,
 ) : PaymentCreatorRequester<Source> {
     override var listener: PaymentCreatorRequestListener? = null
 

--- a/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
+++ b/sdk/src/main/java/co/omise/android/ui/PaymentCreatorActivity.kt
@@ -158,7 +158,6 @@ class PaymentCreatorActivity : OmiseActivity() {
     private fun updateActivityWithCapability(newCapability: Capability) {
         capability = newCapability
         requester = PaymentCreatorRequesterImpl(client, amount, currency, newCapability)
-        requester.capability = newCapability
         navigation =
             PaymentCreatorNavigationImpl(
                 this,
@@ -503,7 +502,7 @@ private class PaymentCreatorNavigationImpl(
 interface PaymentCreatorRequester<T : Model> {
     val amount: Long
     val currency: String
-    var capability: Capability
+    val capability: Capability
 
     fun request(
         request: Request<T>,
@@ -521,7 +520,7 @@ private class PaymentCreatorRequesterImpl(
     private val client: Client,
     override val amount: Long,
     override val currency: String,
-    override var capability: Capability,
+    override val capability: Capability,
 ) : PaymentCreatorRequester<Source> {
     override var listener: PaymentCreatorRequestListener? = null
 

--- a/sdk/src/main/res/layout/activity_payment_creator.xml
+++ b/sdk/src/main/res/layout/activity_payment_creator.xml
@@ -4,5 +4,26 @@
     android:id="@+id/payment_creator_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.PaymentCreatorActivity" />
+    tools:context=".ui.PaymentCreatorActivity">
 
+    <!-- Progress Bar for loading -->
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        android:progress="100"
+        />
+
+    <!-- Error message TextView -->
+    <TextView
+        android:id="@+id/errorMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text=""
+        android:textSize="18sp"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/sdk/src/main/res/values-ja/strings.xml
+++ b/sdk/src/main/res/values-ja/strings.xml
@@ -5,6 +5,7 @@
     <string name="default_form_title">クレジットカード</string>
     <string name="description_brand_logo">カードブランドロゴ</string>
     <string name="error_io">ネットワーク通信エラー, 安定したネット環境で再度試してください. (%1$s)</string>
+    <string name="error_loading_payment_methods">決済方法を読み込むことができません</string>
     <string name="error_invalid_card_number">クレジットカード番号が無効です</string>
     <string name="error_invalid_card_name">クレジットカード所有者名が無効です</string>
     <string name="error_invalid_expiration_date">クレジットカードの有効期限が無効です</string>

--- a/sdk/src/main/res/values-th/strings.xml
+++ b/sdk/src/main/res/values-th/strings.xml
@@ -5,6 +5,7 @@
     <string name="default_form_title">บัตรเครดิต</string>
     <string name="description_brand_logo">โลโก้บัตรเครดิต</string>
     <string name="error_io">ไม่สามารถเชื่อมต่ออินเตอร์เน็ทได้ กรุณาตรวจสอบและลองใหม่อีกครั้ง (%1$s)</string>
+    <string name="error_loading_payment_methods">โหลดวิธีการชำระเงินไม่สำเร็จ</string>
 
     <string name="error_invalid_card_number">หมายเลขบัตรไม่ถูกต้อง</string>
     <string name="error_invalid_card_name">ชื่อผู้ถือบัตรไม่ถูกต้อง</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="default_form_title">Credit Card</string>
     <string name="description_brand_logo">Card brand logo</string>
     <string name="error_io">Network communication error, please make sure you have a stable internet connection. (%1$s)</string>
+    <string name="error_loading_payment_methods">Unable to load payment methods</string>
     <string name="error_invalid_card_number">Credit card number is invalid</string>
     <string name="error_invalid_card_name">Card holder name is invalid</string>
     <string name="error_invalid_expiration_date">Card expiration date is invalid</string>


### PR DESCRIPTION
## Description

Enhancement:
- Load the capability object from the SDK side and the merchant is no longer required to load in the app using the SDK
- Hard coded values like the `installment_terms` and some lists of banks have been removed and are now loaded from capabilities.
- Cross filter payment methods between capabilities and merchant request, ex:
merchant requests methods 1,2,3
capability contains methods 2,3
result: 2,3 are displayed