### PR TITLE
Fix tokenization methods filtering

### DIFF
--- a/sdk/src/androidTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
+++ b/sdk/src/androidTest/java/co/omise/android/ui/PaymentCreatorActivityTest.kt
@@ -145,11 +145,11 @@ class PaymentCreatorActivityTest {
         onView(
             withListId(R.id.recycler_view).atPosition(1),
         ).check(matches(ViewMatchers.isEnabled()))
-            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.googlepay))))
+            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.payment_truemoney_title))))
         onView(
             withListId(R.id.recycler_view).atPosition(2),
         ).check(matches(ViewMatchers.isEnabled()))
-            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.payment_truemoney_title))))
+            .check(matches(ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.googlepay))))
         onView(ViewMatchers.withText(R.string.payment_method_fpx_title)).check(doesNotExist())
         onView(withId(R.id.recycler_view))
             .check(matches(itemCount(3)))

--- a/sdk/src/main/java/co/omise/android/models/Capability.kt
+++ b/sdk/src/main/java/co/omise/android/models/Capability.kt
@@ -3,7 +3,6 @@ package co.omise.android.models
 import co.omise.android.api.Endpoint
 import co.omise.android.api.RequestBuilder
 import co.omise.android.models.PaymentMethod.Companion.createSourceTypeMethod
-import co.omise.android.models.PaymentMethod.Companion.createTokenizationMethod
 import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.android.parcel.Parcelize
 import okhttp3.HttpUrl
@@ -34,7 +33,6 @@ data class Capability(
     override var created: DateTime? = null,
     override var deleted: Boolean = false,
 ) : Model {
-
     /**
      * The {@link RequestBuilder} class for retrieving account Capabilities.
      */
@@ -73,7 +71,7 @@ data class Capability(
                 paymentMethods = paymentMethods,
                 zeroInterestInstallments = zeroInterestInstallments,
                 limits = Limits(InstallmentAmount(200000L)),
-                tokenizationMethods = tokenizationMethods.map { tokenizationMethod -> tokenizationMethod.name!! }
+                tokenizationMethods = tokenizationMethods.map { tokenizationMethod -> tokenizationMethod.name!! },
             )
         }
     }

--- a/sdk/src/main/java/co/omise/android/models/Capability.kt
+++ b/sdk/src/main/java/co/omise/android/models/Capability.kt
@@ -34,19 +34,6 @@ data class Capability(
     override var created: DateTime? = null,
     override var deleted: Boolean = false,
 ) : Model {
-    init {
-        // Need to add them to payment methods as we use tokenization methods as payment methods as well
-        tokenizationMethods?.forEach {
-                tokenizationMethod ->
-            paymentMethods?.add(
-                (
-                    PaymentMethod(
-                        name = tokenizationMethod,
-                    )
-                ),
-            )
-        }
-    }
 
     /**
      * The {@link RequestBuilder} class for retrieving account Capabilities.
@@ -81,13 +68,12 @@ data class Capability(
                 paymentMethods.add(PaymentMethod.createCreditCardMethod())
             }
 
-            paymentMethods.addAll(tokenizationMethods.map(::createTokenizationMethod))
             paymentMethods.addAll(sourceTypes.map(::createSourceTypeMethod))
-
             return Capability(
                 paymentMethods = paymentMethods,
                 zeroInterestInstallments = zeroInterestInstallments,
                 limits = Limits(InstallmentAmount(200000L)),
+                tokenizationMethods = tokenizationMethods.map { tokenizationMethod -> tokenizationMethod.name!! }
             )
         }
     }

--- a/sdk/src/test/java/co/omise/android/TokenizationMethodTest.kt
+++ b/sdk/src/test/java/co/omise/android/TokenizationMethodTest.kt
@@ -36,8 +36,8 @@ class TokenizationMethodTest {
             )
 
         capability.paymentMethods?.any { it.name == "Method no: 1" }?.let { assertTrue(it) }
-        capability.paymentMethods?.any { it.name == "googlepay" }?.let { assertTrue(it) }
-        capability.paymentMethods?.any { it.name == "kanpay" }?.let { assertTrue(it) }
+        capability.tokenizationMethods?.any { it == "googlepay" }?.let { assertTrue(it) }
+        capability.tokenizationMethods?.any { it == "kanpay" }?.let { assertTrue(it) }
     }
 
     @Test


### PR DESCRIPTION
## Description

In some cases the tokenization methods were displayed when not requested and in order to avoid such cases, the filtering has been centralized to only be in the `filterCapabilities` function and removed from the `init` of the capabilities model.