### PR TITLE
Remove obsolete envs

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -20,12 +20,6 @@ android {
         compileSdk compile_sdk_version
         buildConfigField "int", "VERSION_CODE", "$omise_sdk_code_version"
         buildConfigField "String", "VERSION_NAME", "\"$omise_sdk_version\""
-        buildConfigField "String", "NETCETERA_API_KEY", "\"${System.getenv('NETCETERA_API_KEY')}\""
-        buildConfigField "String", "SCHEME_NAME", "\"${System.getenv('SCHEME_NAME')}\""
-        buildConfigField "String", "DS_ID", "\"${System.getenv('DS_ID')}\""
-        buildConfigField "String", "MESSAGE_VERSION", "\"${System.getenv('MESSAGE_VERSION')}\""
-        buildConfigField "String", "ACS_REF_NUMBER", "\"${System.getenv('ACS_REF_NUMBER')}\""
-        buildConfigField "String", "DS_PUBLIC_KEY", "\"${System.getenv('DS_PUBLIC_KEY')}\""
         testInstrumentationRunner "co.omise.android.OmiseTestRunner"
     }
 


### PR DESCRIPTION
## Description

Some envs were used before the introduction of the proper config endpoint. Now that the config endpoint is already integrated these envs should be removed. No impact is caused by their presence.