### PR TITLE
Fix 3ds auth release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Some request methods allow the user to authorize the payment with an external ap
 
 ## ProGuard rules
 
-If you enable ProGuard, then add these rules to your ProGuard file.
+If you enable ProGuard, then add these rules to your ProGuard file and apply any missing rules that your IDE notifies you about. 
 
 ```ProGuard
 -dontwarn okio.**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,5 +23,30 @@
 -dontwarn javax.annotation.**
 -dontwarn com.squareup.**
 
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE
+
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient
+-dontwarn javax.mail.Address
+-dontwarn javax.mail.Authenticator
+-dontwarn javax.mail.BodyPart
+-dontwarn javax.mail.Message$RecipientType
+-dontwarn javax.mail.Message
+-dontwarn javax.mail.Multipart
+-dontwarn javax.mail.PasswordAuthentication
+-dontwarn javax.mail.Session
+-dontwarn javax.mail.Transport
+-dontwarn javax.mail.internet.AddressException
+-dontwarn javax.mail.internet.InternetAddress
+-dontwarn javax.mail.internet.MimeBodyPart
+-dontwarn javax.mail.internet.MimeMessage
+-dontwarn javax.mail.internet.MimeMultipart
+-dontwarn org.w3c.dom.bootstrap.DOMImplementationRegistry
+
 -keep class co.omise.android.** { *; }
 -keep class com.nimbusds.jose.** { *; }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -21,6 +21,7 @@ android {
         buildConfigField "int", "VERSION_CODE", "$omise_sdk_code_version"
         buildConfigField "String", "VERSION_NAME", "\"$omise_sdk_version\""
         testInstrumentationRunner "co.omise.android.OmiseTestRunner"
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     buildTypes {

--- a/sdk/src/main/java/co/omise/android/ThreeDS2ServiceWrapper.kt
+++ b/sdk/src/main/java/co/omise/android/ThreeDS2ServiceWrapper.kt
@@ -1,10 +1,10 @@
 package co.omise.android
 
-import NetceteraConfig
 import android.app.Activity
 import android.content.Context
 import android.os.Build
 import android.util.Base64
+import co.omise.android.models.NetceteraConfig
 import com.netcetera.threeds.sdk.api.ThreeDS2Service
 import com.netcetera.threeds.sdk.api.configparameters.builder.ConfigurationBuilder
 import com.netcetera.threeds.sdk.api.configparameters.builder.SchemeConfiguration

--- a/sdk/src/main/java/co/omise/android/ThreeDSConfigProvider.kt
+++ b/sdk/src/main/java/co/omise/android/ThreeDSConfigProvider.kt
@@ -1,6 +1,7 @@
 import android.net.Uri
 import co.omise.android.AuthorizingPaymentURLVerifier
 import co.omise.android.api.Client
+import co.omise.android.models.NetceteraConfig
 import com.netcetera.threeds.sdk.api.exceptions.InvalidInputException
 import java.net.URL
 

--- a/sdk/src/main/java/co/omise/android/models/NetceteraConfig.kt
+++ b/sdk/src/main/java/co/omise/android/models/NetceteraConfig.kt
@@ -1,5 +1,5 @@
+package co.omise.android.models
 import co.omise.android.api.RequestBuilder
-import co.omise.android.models.Model
 import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.android.parcel.Parcelize
 import okhttp3.HttpUrl

--- a/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
+++ b/sdk/src/main/java/co/omise/android/ui/AuthorizingPaymentViewModel.kt
@@ -1,6 +1,5 @@
 package co.omise.android.ui
 
-import NetceteraConfig
 import ThreeDSConfigProvider
 import android.app.Activity
 import androidx.lifecycle.LiveData
@@ -14,6 +13,7 @@ import co.omise.android.ThreeDS2ServiceWrapper
 import co.omise.android.api.Client
 import co.omise.android.config.UiCustomization
 import co.omise.android.models.Authentication
+import co.omise.android.models.NetceteraConfig
 import co.omise.android.models.Serializer
 import com.netcetera.threeds.sdk.ThreeDS2ServiceInstance
 import com.netcetera.threeds.sdk.api.transaction.Transaction

--- a/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
+++ b/sdk/src/test/java/co/omise/android/ui/AuthorizingPaymentViewModelTest.kt
@@ -1,6 +1,5 @@
 package co.omise.android.ui
 
-import NetceteraConfig
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.AuthorizingPaymentURLVerifier
@@ -11,6 +10,7 @@ import co.omise.android.api.Request
 import co.omise.android.models.Authentication
 import co.omise.android.models.Authentication.AuthenticationStatus
 import co.omise.android.models.AuthenticationAPIError
+import co.omise.android.models.NetceteraConfig
 import com.netcetera.threeds.sdk.api.exceptions.InvalidInputException
 import com.netcetera.threeds.sdk.api.exceptions.SDKRuntimeException
 import com.netcetera.threeds.sdk.api.transaction.AuthenticationRequestParameters

--- a/sdk/src/test/java/co/omise/android/ui/ThreeDsConfigProviderTest.kt
+++ b/sdk/src/test/java/co/omise/android/ui/ThreeDsConfigProviderTest.kt
@@ -2,6 +2,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import co.omise.android.AuthorizingPaymentURLVerifier
 import co.omise.android.api.Client
 import co.omise.android.api.Request
+import co.omise.android.models.NetceteraConfig
 import com.netcetera.threeds.sdk.api.exceptions.InvalidInputException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest


### PR DESCRIPTION
## Description

Fix the issue when using the SDK in release mode for version v5.x till v5.3.0 . 

## Scenario 
If the integrator was using pro guard and trying to access the auth uri flow using native 3ds flow, then the SDK will crash since some classes were missing during the R8 process/proguard obfuscation. 
