### PR TITLE
Set card brand variable to public

### DIFF
--- a/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.kt
+++ b/sdk/src/main/java/co/omise/android/ui/CreditCardEditText.kt
@@ -30,7 +30,7 @@ class CreditCardEditText : OmiseEditText {
     val cardNumber: String
         get() = text.toString().trim().replace(SEPARATOR, "")
 
-    private val cardBrand: CardBrand?
+    val cardBrand: CardBrand?
         get() = CardNumber.brand(cardNumber)
 
     constructor(context: Context) : super(context)


### PR DESCRIPTION
## Description

Set card brand back to public to allow merchants to access the card brand from the card number textfield. 

closes #357 